### PR TITLE
0.4.0 rust_dlc migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 **/*.rs.bk
 /events_db*
 /contracts_db
+/wallet_db
 .vscode
 .env
 !.env.tempalte

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,16 +21,16 @@ dependencies = [
 
 [[package]]
 name = "actix-http"
-version = "3.2.2"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c83abf9903e1f0ad9973cc4f7b9767fd5a03a583f51a5b7a339e07987cd2724"
+checksum = "0070905b2c4a98d184c4e81025253cb192aa8a73827553f38e9410801ceb35bb"
 dependencies = [
  "actix-codec",
  "actix-rt",
  "actix-service",
  "actix-utils",
  "ahash",
- "base64",
+ "base64 0.21.0",
  "bitflags",
  "brotli",
  "bytes",
@@ -52,6 +52,8 @@ dependencies = [
  "rand 0.8.5",
  "sha1",
  "smallvec",
+ "tokio",
+ "tokio-util",
  "tracing",
  "zstd",
 ]
@@ -81,9 +83,9 @@ dependencies = [
 
 [[package]]
 name = "actix-rt"
-version = "2.7.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ea16c295198e958ef31930a6ef37d0fb64e9ca3b6116e6b93a8bdae96ee1000"
+checksum = "15265b6b8e2347670eb363c47fc8c75208b4a4994b27192f345fcbe707804f3e"
 dependencies = [
  "futures-core",
  "tokio",
@@ -91,9 +93,9 @@ dependencies = [
 
 [[package]]
 name = "actix-server"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0da34f8e659ea1b077bb4637948b815cd3768ad5a188fdcd74ff4d84240cd824"
+checksum = "3e8613a75dd50cc45f473cee3c34d59ed677c0f7b44480ce3b8247d7dc519327"
 dependencies = [
  "actix-rt",
  "actix-service",
@@ -130,9 +132,9 @@ dependencies = [
 
 [[package]]
 name = "actix-web"
-version = "4.2.1"
+version = "4.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d48f7b6534e06c7bfc72ee91db7917d4af6afe23e7d223b51e68fffbb21e96b9"
+checksum = "cd3cb42f9566ab176e1ef0b8b3a896529062b4efc6be0123046095914c4c1c96"
 dependencies = [
  "actix-codec",
  "actix-http",
@@ -165,15 +167,15 @@ dependencies = [
  "serde_urlencoded",
  "smallvec",
  "socket2",
- "time 0.3.17",
+ "time 0.3.20",
  "url",
 ]
 
 [[package]]
 name = "actix-web-codegen"
-version = "4.1.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa9362663c8643d67b2d5eafba49e4cb2c8a053a29ed00a0bea121f17c76b13"
+checksum = "2262160a7ae29e3415554a3f1fc04c764b1540c116aa524683208078b7a75bc9"
 dependencies = [
  "actix-router",
  "proc-macro2",
@@ -239,9 +241,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
+checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
 
 [[package]]
 name = "ascii"
@@ -261,9 +263,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.60"
+version = "0.1.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d1d8ab452a3936018a687b20e6f7cf5363d713b732b8884001317b0e48aa3"
+checksum = "1cd7fce9ba8c3c042128ce72d8b2ddbf3a05747efb67ea0313c635e10bda47a2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -303,6 +305,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
+name = "base64"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
+
+[[package]]
 name = "base64-compat"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -318,27 +326,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf9ff0bbfd639f15c74af777d81383cf53efb7c93613f6cab67c6c11e05bbf8b"
 
 [[package]]
+name = "bech32"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
+
+[[package]]
 name = "bitcoin"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a41df6ad9642c5c15ae312dd3d074de38fd3eb7cc87ad4ce10f90292a83fe4d"
 dependencies = [
- "bech32",
+ "bech32 0.8.1",
  "bitcoin_hashes 0.10.0",
  "secp256k1 0.20.3",
+]
+
+[[package]]
+name = "bitcoin"
+version = "0.29.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0694ea59225b0c5f3cb405ff3f670e4828358ed26aec49dc352f730f0cb1a8a3"
+dependencies = [
+ "bech32 0.9.1",
+ "bitcoin_hashes 0.11.0",
+ "secp256k1 0.24.3",
  "serde",
 ]
 
 [[package]]
 name = "bitcoin-rpc-provider"
-version = "0.3.0"
-source = "git+https://github.com/dlc-link/rust-dlc?branch=0.3.0-with-witness-fix#0bbd601689fb53b2d4067596535f652a39788968"
+version = "0.1.0"
+source = "git+https://github.com/p2pderivatives/rust-dlc#ca4f9b04e652710d98cd4178fe1225285e3c8752"
 dependencies = [
- "bitcoin",
+ "bitcoin 0.29.2",
  "bitcoincore-rpc",
  "bitcoincore-rpc-json",
  "dlc-manager",
+ "lightning 0.0.113",
+ "log",
  "rust-bitcoin-coin-selection",
+ "simple-wallet",
 ]
 
 [[package]]
@@ -352,14 +380,21 @@ name = "bitcoin_hashes"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "006cc91e1a1d99819bc5b8214be3555c1f0611b169f527a1fdc54ed1f2b745b0"
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90064b8dee6815a6470d60bad07bbbaee885c0e12d04177138fa3291a01b7bc4"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "bitcoincore-rpc"
-version = "0.13.0"
-source = "git+https://github.com/p2pderivatives/rust-bitcoincore-rpc?branch=dlc-version#78785ea8968586aaa4edbf991eb4b1070283cb4b"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0261b2bb7617e0c91b452a837bbd1291fd34ad6990cb8e3ffc28239cc045b5ca"
 dependencies = [
  "bitcoincore-rpc-json",
  "jsonrpc",
@@ -370,10 +405,11 @@ dependencies = [
 
 [[package]]
 name = "bitcoincore-rpc-json"
-version = "0.13.0"
-source = "git+https://github.com/p2pderivatives/rust-bitcoincore-rpc?branch=dlc-version#78785ea8968586aaa4edbf991eb4b1070283cb4b"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c231bea28e314879c5aef240f6052e8a72a369e3c9f9b20d9bfbb33ad18029b2"
 dependencies = [
- "bitcoin",
+ "bitcoin 0.29.2",
  "serde",
  "serde_json",
 ]
@@ -406,9 +442,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "2.3.2"
+version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ad2d4653bf5ca36ae797b1f4bb4dbddb60ce49ca4aed8a2ce4829f60425b80"
+checksum = "4b6561fd3f895a11e8f72af2cb7d22e08366bebc2b6b57f7744c4bda27034744"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -416,11 +452,12 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "0.2.17"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
+checksum = "5ffdb39cb703212f3c11973452c2861b972f757b021158f3516ba10f2fa8b2c1"
 dependencies = [
  "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -435,9 +472,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.11.1"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
+checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
 name = "bytecount"
@@ -453,9 +490,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
+checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
 name = "bytestring"
@@ -468,9 +505,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.78"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 dependencies = [
  "jobserver",
 ]
@@ -499,9 +536,9 @@ dependencies = [
 
 [[package]]
 name = "chunked_transfer"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fff857943da45f546682664a79488be82e69e43c1a7a2307679ab9afb3a66d2e"
+checksum = "cca491388666e04d7248af3f60f0c40cfb0991c72205595d7c396e3510207d1a"
 
 [[package]]
 name = "clap"
@@ -522,18 +559,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.0.32"
+version = "4.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7db700bc935f9e43e88d00b0850dae18a63773cfbec6d8e070fccf7fef89a39"
+checksum = "c3d7ae14b20b94cb02149ed21a86c423859cbe18dc7ed69845cace50e52b40a5"
 dependencies = [
  "bitflags",
- "clap_derive 4.0.21",
- "clap_lex 0.3.0",
+ "clap_derive 4.1.8",
+ "clap_lex 0.3.2",
  "is-terminal",
  "once_cell",
  "strsim",
  "termcolor",
- "terminal_size 0.2.3",
+ "terminal_size",
 ]
 
 [[package]]
@@ -542,7 +579,7 @@ version = "3.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
 dependencies = [
- "heck 0.4.0",
+ "heck 0.4.1",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -551,11 +588,11 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.0.21"
+version = "4.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0177313f9f02afc995627906bbd8967e2be069f5261954222dac78290c2b9014"
+checksum = "44bec8e5c9d09e439c4335b1af0abaab56dcf3b94999a936e1bb47b9134288f0"
 dependencies = [
- "heck 0.4.0",
+ "heck 0.4.1",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -573,9 +610,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
+checksum = "350b9cf31731f9957399229e9b2adc51eeabdfbe9d71d9a0552275fd12710d09"
 dependencies = [
  "os_str_bytes",
 ]
@@ -640,16 +677,15 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.2"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c050367d967ced717c04b65d8c619d863ef9292ce0c5760028655a2fb298718c"
+checksum = "c3d79fbe8970a77e3e34151cc13d3b3e248aa0faaecb9f6091fa07ebefe5ad60"
 dependencies = [
  "encode_unicode",
  "lazy_static",
  "libc",
- "terminal_size 0.1.17",
  "unicode-width",
- "winapi",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -665,7 +701,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e859cd57d0710d9e06c381b550c06e76992472a8c6d527aecd2fc673dcc231fb"
 dependencies = [
  "percent-encoding",
- "time 0.3.17",
+ "time 0.3.20",
  "version_check",
 ]
 
@@ -705,9 +741,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
+checksum = "cf2b3e8478797446514c91ef04bafcb59faba183e621ad488df88983cc14128c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -715,9 +751,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
+checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
 dependencies = [
  "cfg-if",
  "crossbeam-epoch",
@@ -726,9 +762,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.13"
+version = "0.9.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01a9af1f4c2ef74bb8aa1f7e19706bc72d03598c8a570bb5de72243c7a9d9d5a"
+checksum = "46bd5f3f85273295a9d14aedfb86f6aadbff6d8f5295c4a9edb08e819dcf5695"
 dependencies = [
  "autocfg 1.1.0",
  "cfg-if",
@@ -739,9 +775,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.14"
+version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
+checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
 dependencies = [
  "cfg-if",
 ]
@@ -768,14 +804,14 @@ dependencies = [
 
 [[package]]
 name = "cucumber"
-version = "0.19.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74f0a8148f50395243f5e93d39893a6d8e3449097501ccd97c162967dfe8877c"
+checksum = "a845da7c9fb958144700201d22e3f61f55114f9e269c13f03fe179d9da500984"
 dependencies = [
  "anyhow",
  "async-trait",
  "atty",
- "clap 4.0.32",
+ "clap 4.1.8",
  "console",
  "cucumber-codegen",
  "cucumber-expressions",
@@ -797,9 +833,9 @@ dependencies = [
 
 [[package]]
 name = "cucumber-codegen"
-version = "0.19.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d10b08005214a8119b331a362822e17b2bcfdf0944f5854120a81f6b939ec96a"
+checksum = "0dfb841fe8742f57fbe94738a189022e7dc858f2560c7fba5da44dc945a139e1"
 dependencies = [
  "cucumber-expressions",
  "inflections",
@@ -827,9 +863,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.85"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5add3fc1717409d029b20c5b6903fc0c0b02fa6741d820054f4a2efa5e5816fd"
+checksum = "86d3488e7665a7a483b57e25bdd90d0aeb2bc7608c8d0346acf2ad3f1caf1d62"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -839,9 +875,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.85"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c87959ba14bc6fbc61df77c3fcfe180fc32b93538c4f1031dd802ccb5f2ff0"
+checksum = "48fcaf066a053a41a81dfb14d57d99738b767febb8b735c3016e469fac5da690"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -854,15 +890,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.85"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69a3e162fde4e594ed2b07d0f83c6c67b745e7f28ce58c6df5e6b6bef99dfb59"
+checksum = "a2ef98b8b717a829ca5603af80e1f9e2e48013ab227b68ef37872ef84ee479bf"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.85"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e7e2adeb6a0d4a282e581096b06e1791532b7d576dcde5ccd9382acf55db8e6"
+checksum = "086c685979a698443656e5cf7856c95c642295a38599f12fb1ff76fb28d19892"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -871,9 +907,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.14.2"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0dd3cd20dc6b5a876612a6e5accfe7f3dd883db6d07acfbf14c128f61550dfa"
+checksum = "c0808e1bd8671fb44a113a14e13497557533369847788fa2ae912b6ebfce9fa8"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -881,9 +917,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.14.2"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a784d2ccaf7c98501746bf0be29b2022ba41fd62a2e622af997a03e9f972859f"
+checksum = "001d80444f28e193f30c2f293455da62dcf9a6b29918a4253152ae2b1de592cb"
 dependencies = [
  "fnv",
  "ident_case",
@@ -895,9 +931,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.14.2"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7618812407e9402654622dd402b0a89dff9ba93badd6540781526117b92aab7e"
+checksum = "b36230598a2d5de7ec1c6f51f72d8a99a9208daff41de2084d06e3fd3ea56685"
 dependencies = [
  "darling_core",
  "quote",
@@ -960,9 +996,9 @@ dependencies = [
 
 [[package]]
 name = "diesel"
-version = "2.0.2"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68c186a7418a2aac330bb76cde82f16c36b03a66fb91db32d20214311f9f6545"
+checksum = "4391a22b19c916e50bec4d6140f29bdda3e3bb187223fe6e3ea0b6e4d1021c04"
 dependencies = [
  "bitflags",
  "byteorder",
@@ -996,12 +1032,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "difference"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
-
-[[package]]
 name = "digest"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1028,19 +1058,20 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092bf1d5cb6d55880b4b033e7b7c396b4b34197b74a27ff5dd41fd352e0a65bd"
 dependencies = [
- "bitcoin",
+ "bitcoin 0.27.1",
  "secp256k1-sys 0.4.1",
  "secp256k1-zkp 0.5.0",
 ]
 
 [[package]]
 name = "dlc"
-version = "0.3.0"
-source = "git+https://github.com/dlc-link/rust-dlc?branch=0.3.0-with-witness-fix#0bbd601689fb53b2d4067596535f652a39788968"
+version = "0.4.0"
+source = "git+https://github.com/p2pderivatives/rust-dlc#ca4f9b04e652710d98cd4178fe1225285e3c8752"
 dependencies = [
- "bitcoin",
- "secp256k1-sys 0.4.1",
- "secp256k1-zkp 0.5.0",
+ "bitcoin 0.29.2",
+ "miniscript",
+ "secp256k1-sys 0.6.1",
+ "secp256k1-zkp 0.7.0",
  "serde",
 ]
 
@@ -1066,17 +1097,17 @@ dependencies = [
 
 [[package]]
 name = "dlc-manager"
-version = "0.3.0"
-source = "git+https://github.com/dlc-link/rust-dlc?branch=0.3.0-with-witness-fix#0bbd601689fb53b2d4067596535f652a39788968"
+version = "0.4.0"
+source = "git+https://github.com/p2pderivatives/rust-dlc#ca4f9b04e652710d98cd4178fe1225285e3c8752"
 dependencies = [
  "async-trait",
- "bitcoin",
- "dlc 0.3.0 (git+https://github.com/dlc-link/rust-dlc?branch=0.3.0-with-witness-fix)",
- "dlc-messages 0.3.0 (git+https://github.com/dlc-link/rust-dlc?branch=0.3.0-with-witness-fix)",
+ "bitcoin 0.29.2",
+ "dlc 0.4.0",
+ "dlc-messages 0.4.0",
  "dlc-trie",
- "lightning",
+ "lightning 0.0.113",
  "log",
- "secp256k1-zkp 0.5.0",
+ "secp256k1-zkp 0.7.0",
  "serde",
 ]
 
@@ -1086,21 +1117,21 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f923460bf8fb18986ff5d986fb83e2713a559b56c9d2a74808da11525a54f162"
 dependencies = [
- "bitcoin",
- "dlc 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lightning",
+ "bitcoin 0.27.1",
+ "dlc 0.3.0",
+ "lightning 0.0.106",
  "secp256k1-zkp 0.5.0",
 ]
 
 [[package]]
 name = "dlc-messages"
-version = "0.3.0"
-source = "git+https://github.com/dlc-link/rust-dlc?branch=0.3.0-with-witness-fix#0bbd601689fb53b2d4067596535f652a39788968"
+version = "0.4.0"
+source = "git+https://github.com/p2pderivatives/rust-dlc#ca4f9b04e652710d98cd4178fe1225285e3c8752"
 dependencies = [
- "bitcoin",
- "dlc 0.3.0 (git+https://github.com/dlc-link/rust-dlc?branch=0.3.0-with-witness-fix)",
- "lightning",
- "secp256k1-zkp 0.5.0",
+ "bitcoin 0.29.2",
+ "dlc 0.4.0",
+ "lightning 0.0.113",
+ "secp256k1-zkp 0.7.0",
  "serde",
 ]
 
@@ -1108,25 +1139,25 @@ dependencies = [
 name = "dlc-protocol-wallet"
 version = "0.1.0"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "bitcoin-rpc-provider",
  "bitcoincore-rpc",
  "bitcoincore-rpc-json",
  "chrono",
- "dlc 0.3.0 (git+https://github.com/dlc-link/rust-dlc?branch=0.3.0-with-witness-fix)",
+ "dlc 0.4.0",
  "dlc-clients",
  "dlc-manager",
- "dlc-messages 0.3.0 (git+https://github.com/dlc-link/rust-dlc?branch=0.3.0-with-witness-fix)",
+ "dlc-messages 0.4.0",
  "dlc-sled-storage-provider",
  "dlc-trie",
  "env_logger",
  "hex",
- "lightning",
+ "lightning 0.0.113",
  "log",
  "mockito",
  "reqwest",
  "rouille",
- "secp256k1-zkp 0.5.0",
+ "secp256k1-zkp 0.7.0",
  "serde",
  "serde_json",
  "sled",
@@ -1137,7 +1168,7 @@ dependencies = [
 [[package]]
 name = "dlc-sled-storage-provider"
 version = "0.1.0"
-source = "git+https://github.com/dlc-link/rust-dlc?branch=0.3.0-with-witness-fix#0bbd601689fb53b2d4067596535f652a39788968"
+source = "git+https://github.com/p2pderivatives/rust-dlc#ca4f9b04e652710d98cd4178fe1225285e3c8752"
 dependencies = [
  "dlc-manager",
  "sled",
@@ -1189,12 +1220,12 @@ dependencies = [
 
 [[package]]
 name = "dlc-trie"
-version = "0.3.0"
-source = "git+https://github.com/dlc-link/rust-dlc?branch=0.3.0-with-witness-fix#0bbd601689fb53b2d4067596535f652a39788968"
+version = "0.4.0"
+source = "git+https://github.com/p2pderivatives/rust-dlc#ca4f9b04e652710d98cd4178fe1225285e3c8752"
 dependencies = [
- "bitcoin",
- "dlc 0.3.0 (git+https://github.com/dlc-link/rust-dlc?branch=0.3.0-with-witness-fix)",
- "secp256k1-zkp 0.5.0",
+ "bitcoin 0.29.2",
+ "dlc 0.4.0",
+ "secp256k1-zkp 0.7.0",
  "serde",
 ]
 
@@ -1218,15 +1249,15 @@ checksum = "03d8c417d7a8cb362e0c37e5d815f5eb7c37f79ff93707329d5a194e42e54ca0"
 
 [[package]]
 name = "drain_filter_polyfill"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca9f76bdd86dfc8d64eecb0484d02ad4cf0e6767d4682f686d1b0580b6c27f82"
+checksum = "669a445ee724c5c69b1b06fe0b63e70a1c84bc9bb7d9696cd4f4e3ec45050408"
 
 [[package]]
 name = "either"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "encode_unicode"
@@ -1236,9 +1267,9 @@ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.31"
+version = "0.8.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
+checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
 dependencies = [
  "cfg-if",
 ]
@@ -1279,23 +1310,23 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
 dependencies = [
  "instant",
 ]
 
 [[package]]
 name = "filetime"
-version = "0.2.19"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e884668cd0c7480504233e951174ddc3b382f7c2666e3b7310b5c4e7b0c37f9"
+checksum = "8a3de6e8d11b22ff9edc6d916f890800597d60f8b2da1caf2955c274638d6412"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1356,9 +1387,9 @@ checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "futures"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38390104763dc37a5145a53c29c63c1290b5d316d6086ec32c293f6736051bb0"
+checksum = "13e2792b0ff0340399d58445b88fd9770e3489eff258a4cbc1523418f12abf84"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1371,9 +1402,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ba265a92256105f45b719605a571ffe2d1f0fea3807304b522c1d778f79eed"
+checksum = "2e5317663a9089767a1ec00a487df42e0ca174b61b4483213ac24448e4664df5"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1381,15 +1412,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04909a7a7e4633ae6c4a9ab280aeb86da1236243a77b694a49eacd659a4bd3ac"
+checksum = "ec90ff4d0fe1f57d600049061dc6bb68ed03c7d2fbd697274c41805dcb3f8608"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7acc85df6714c176ab5edf386123fafe217be88c0840ec11f199441134a074e2"
+checksum = "e8de0a35a6ab97ec8869e32a2473f4b1324459e14c29275d14b10cb1fd19b50e"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1398,15 +1429,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
+checksum = "bfb8371b6fb2aeb2d280374607aeabfc99d95c72edfe51692e42d3d7f0d08531"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
+checksum = "95a73af87da33b5acf53acfebdc339fe592ecf5357ac7c0a7734ab9d8c876a70"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1415,21 +1446,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39c15cf1a4aa79df40f1bb462fb39676d0ad9e366c2a33b590d7c66f4f81fcf9"
+checksum = "f310820bb3e8cfd46c80db4d7fb8353e15dfff853a127158425f31e0be6c8364"
 
 [[package]]
 name = "futures-task"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffb393ac5d9a6eaa9d3fdf37ae2776656b706e200c8e16b1bdb227f5198e6ea"
+checksum = "dcf79a1bf610b10f42aea489289c5a2c478a786509693b80cd39c44ccd936366"
 
 [[package]]
 name = "futures-util"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6"
+checksum = "9c1d6de3acfef38d2be4b1f543f553131788603495be83da675e180c8d6b7bd1"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1489,7 +1520,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e8f8f49b2b547ec22cc4d99f3bf30d4889ef0dbaa231c0736eeaf20efb5a38e"
 dependencies = [
- "heck 0.4.0",
+ "heck 0.4.1",
  "peg",
  "quote",
  "serde",
@@ -1513,9 +1544,9 @@ dependencies = [
 
 [[package]]
 name = "globset"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a1e17342619edbc21a964c2afbeb6c820c6a2560032872f397bb97ea127bd0a"
+checksum = "029d74589adefde59de1a0c4f4732695c32805624aec7b68d91503d4dba79afc"
 dependencies = [
  "aho-corasick",
  "bstr",
@@ -1546,9 +1577,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f9f29bc9dda355256b2916cf526ab02ce0aeaaaf2bad60d65ef3f12f11dd0f4"
+checksum = "5be7b54589b581f624f566bf5d8eb2bab1db736c51528720b6bd36b96b55924d"
 dependencies = [
  "bytes",
  "fnv",
@@ -1578,7 +1609,7 @@ version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3e372db8e5c0d213e0cd0b9be18be2aca3d44cf2fe30a9d46a65581cd454584"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "bitflags",
  "bytes",
  "headers-core",
@@ -1608,9 +1639,9 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
@@ -1631,6 +1662,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1638,9 +1675,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
+checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
 dependencies = [
  "bytes",
  "fnv",
@@ -1678,9 +1715,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.23"
+version = "0.14.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "034711faac9d2166cb1baf1a2fb0b60b1f277f8492fd72176c17f3515e1abd3c"
+checksum = "5e011372fa0b68db8350aa7a248930ecc7839bf46d8485577d69f117a75f164c"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1768,11 +1805,10 @@ dependencies = [
 
 [[package]]
 name = "ignore"
-version = "0.4.18"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "713f1b139373f96a2e0ce3ac931cd01ee973c3c5dd7c40c0c2efe96ad2b6751d"
+checksum = "dbe7873dab538a9a44ad79ede1faf5f30d49f9a5c883ddbab48bce81b64b7492"
 dependencies = [
- "crossbeam-utils",
  "globset",
  "lazy_static",
  "log",
@@ -1821,30 +1857,30 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.3"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46112a93252b123d31a119a8d1a1ac19deac4fac6e0e8b0df58f0d4e5870e63c"
+checksum = "1abeb7a0dd0f8181267ff8adc397075586500b81b28a73e8a0208b00fc170fb3"
 dependencies = [
  "libc",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
 name = "ipnet"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11b0d96e660696543b251e58030cf9787df56da39dab19ad60eae7353040917e"
+checksum = "30e22bd8629359895450b59ea7a776c850561b96a3b1d31321c1949d9e6c9146"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.2"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dfb6c8100ccc63462345b67d1bbc3679177c75ee4bf59bf29c8b1d110b8189"
+checksum = "21b6b32576413a8e69b90e952e4a026476040d81017b80445deda5f2d3921857"
 dependencies = [
- "hermit-abi 0.2.6",
+ "hermit-abi 0.3.1",
  "io-lifetimes",
  "rustix",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1864,18 +1900,18 @@ checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
 
 [[package]]
 name = "jobserver"
-version = "0.1.25"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "068b1ee6743e4d11fb9c6a1e6064b3693a1b600e7f5f5988047d98b3dc9fb90b"
+checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.60"
+version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
+checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1927,8 +1963,17 @@ version = "0.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "580647f97f8e6d138ad724027c8ca9b890b1001b05374c270bbee4c10309b641"
 dependencies = [
- "bitcoin",
+ "bitcoin 0.27.1",
  "secp256k1 0.20.3",
+]
+
+[[package]]
+name = "lightning"
+version = "0.0.113"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "087add70f81d2fdc6d4409bc0cef69e11ad366ef1d0068550159bd22b3ac8664"
+dependencies = [
+ "bitcoin 0.29.2",
 ]
 
 [[package]]
@@ -1997,9 +2042,9 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memoffset"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
 dependencies = [
  "autocfg 1.1.0",
 ]
@@ -2048,6 +2093,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "miniscript"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f4975078076f0b7b914a3044ad7432d2a7fcec38edb855afdc672e24ca35b69"
+dependencies = [
+ "bitcoin 0.29.2",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2058,25 +2112,24 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
+checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
 dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
 name = "mockito"
-version = "0.30.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d10030163d67f681db11810bc486df3149e6d91c8b4f3f96fa8b62b546c2cef8"
+checksum = "80f9fece9bd97ab74339fe19f4bcaf52b76dcc18e5364c7977c1838f76b38de9"
 dependencies = [
  "assert-json-diff",
  "colored",
- "difference",
  "httparse",
  "lazy_static",
  "log",
@@ -2084,6 +2137,7 @@ dependencies = [
  "regex",
  "serde_json",
  "serde_urlencoded",
+ "similar",
 ]
 
 [[package]]
@@ -2124,9 +2178,9 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "7.1.1"
+version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
@@ -2134,9 +2188,9 @@ dependencies = [
 
 [[package]]
 name = "nom_locate"
-version = "4.0.0"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37794436ca3029a3089e0b95d42da1f0b565ad271e4d3bb4bad0c7bb70b10605"
+checksum = "b1e299bf5ea7b212e811e71174c5d1a5d065c4c0ad0c8691ecb1f97e3e66025e"
 dependencies = [
  "bytecount",
  "memchr",
@@ -2183,9 +2237,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.16.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "openssl"
@@ -2282,7 +2336,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.5",
+ "parking_lot_core 0.9.7",
 ]
 
 [[package]]
@@ -2301,15 +2355,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.5"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ff9f3fef3968a3ec5945535ed654cb38ff72d7495a25619e2247fb15a2ed9ba"
+checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -2359,9 +2413,9 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pest"
-version = "2.5.2"
+version = "2.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f6e86fb9e7026527a0d46bc308b841d73170ef8f443e1807f6ef88526a816d4"
+checksum = "028accff104c4e513bad663bbcd2ad7cfd5304144404c31ed0a77ac103d00660"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -2369,9 +2423,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.5.2"
+version = "2.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96504449aa860c8dcde14f9fba5c58dc6658688ca1fe363589d6327b8662c603"
+checksum = "2ac3922aac69a40733080f53c1ce7f91dcf57e1a5f6c52f421fadec7fbdc4b69"
 dependencies = [
  "pest",
  "pest_generator",
@@ -2379,9 +2433,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.5.2"
+version = "2.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "798e0220d1111ae63d66cb66a5dcb3fc2d986d520b98e49e1852bfdb11d7c5e7"
+checksum = "d06646e185566b5961b4058dd107e0a7f56e77c3f484549fb119867773c0f202"
 dependencies = [
  "pest",
  "pest_meta",
@@ -2392,13 +2446,13 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.5.2"
+version = "2.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "984298b75898e30a843e278a9f2452c31e349a073a0ce6fd950a12a74464e065"
+checksum = "e6f60b2ba541577e2a0c307c8f39d1439108120eb7903adeb6497fa880c59616"
 dependencies = [
  "once_cell",
  "pest",
- "sha1",
+ "sha2",
 ]
 
 [[package]]
@@ -2480,9 +2534,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.49"
+version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
+checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
 dependencies = [
  "unicode-ident",
 ]
@@ -2667,9 +2721,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.10.1"
+version = "1.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cac410af5d00ab6884528b4ab69d1e8e146e8d471201800fa1b4524126de6ad3"
+checksum = "356a0625f1954f730c0201cdab48611198dc6ce21f4acff55089b5a78e6e835b"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
@@ -2697,9 +2751,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
+checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2713,21 +2767,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "reqwest"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68cc60575865c7831548863cc02356512e3f1dc2f3f82cb837d7fc4cc8f3c97c"
+checksum = "21eed90ec8570952d53b772ecf8f206aa1ec9a3d76b2521c56c42973f2d91ee9"
 dependencies = [
- "base64",
+ "base64 0.21.0",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -2747,7 +2792,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustls",
- "rustls-pemfile 1.0.1",
+ "rustls-pemfile 1.0.2",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -2784,7 +2829,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88073939a61e5b7680558e6be56b419e208420c2adb92be54921fa6b72283f1a"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "bitflags",
  "serde",
 ]
@@ -2795,7 +2840,7 @@ version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f86e4c51a773f953f02bbab5fd049f004bfd384341d62da2a079aff812ab176"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "brotli",
  "chrono",
  "deflate",
@@ -2809,7 +2854,7 @@ dependencies = [
  "serde_json",
  "sha1",
  "threadpool",
- "time 0.3.17",
+ "time 0.3.20",
  "tiny_http",
  "url",
 ]
@@ -2877,23 +2922,23 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.6"
+version = "0.36.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4feacf7db682c6c329c4ede12649cd36ecab0f3be5b7d74e6a20304725db4549"
+checksum = "f43abb88211988493c1abb44a70efa56ff0ce98f233b7b276146f1f3f7ba9644"
 dependencies = [
  "bitflags",
  "errno",
  "io-lifetimes",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.20.7"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "539a2bfe908f471bfa933876bd1eb6a19cf2176d375f82ef7f99530a40e48c2c"
+checksum = "fff78fc74d175294f4e83b28343315ffcfb114b156f0185e9741cb5570f50e2f"
 dependencies = [
  "log",
  "ring",
@@ -2907,16 +2952,16 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5eebeaeb360c87bfb72e84abdb3447159c0eaececf1bef2aecd65a8be949d1c9"
 dependencies = [
- "base64",
+ "base64 0.13.1",
 ]
 
 [[package]]
 name = "rustls-pemfile"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0864aeff53f8c05aa08d86e5ef839d3dfcf07aeba2db32f12db0ef716e87bd55"
+checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
 dependencies = [
- "base64",
+ "base64 0.21.0",
 ]
 
 [[package]]
@@ -2942,12 +2987,11 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d6731146462ea25d9244b2ed5fd1d716d25c52e4d54aa4fb0f3c4e9854dbe2"
+checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
 dependencies = [
- "lazy_static",
- "windows-sys 0.36.1",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -3020,7 +3064,6 @@ dependencies = [
  "bitcoin_hashes 0.9.7",
  "rand 0.6.5",
  "secp256k1-sys 0.4.1",
- "serde",
 ]
 
 [[package]]
@@ -3032,6 +3075,18 @@ dependencies = [
  "bitcoin_hashes 0.10.0",
  "rand 0.6.5",
  "secp256k1-sys 0.5.2",
+]
+
+[[package]]
+name = "secp256k1"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1629c9c557ef9b293568b338dddfc8208c98a18c59d722a9d53f859d9c9b62"
+dependencies = [
+ "bitcoin_hashes 0.11.0",
+ "rand 0.8.5",
+ "secp256k1-sys 0.6.1",
+ "serde",
 ]
 
 [[package]]
@@ -3053,6 +3108,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "secp256k1-sys"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83080e2c2fc1006e625be82e5d1eb6a43b7fd9578b617fcc55814daf286bba4b"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "secp256k1-zkp"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3061,7 +3125,6 @@ dependencies = [
  "rand 0.6.5",
  "secp256k1 0.20.3",
  "secp256k1-zkp-sys 0.5.0",
- "serde",
 ]
 
 [[package]]
@@ -3073,6 +3136,18 @@ dependencies = [
  "rand 0.6.5",
  "secp256k1 0.22.2",
  "secp256k1-zkp-sys 0.6.0",
+]
+
+[[package]]
+name = "secp256k1-zkp"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd403e9f0569b4131ab3fc9fa24a17775331b39382efd2cde851fdca655e3520"
+dependencies = [
+ "rand 0.8.5",
+ "secp256k1 0.24.3",
+ "secp256k1-zkp-sys 0.7.0",
+ "serde",
 ]
 
 [[package]]
@@ -3096,10 +3171,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "security-framework"
-version = "2.7.0"
+name = "secp256k1-zkp-sys"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bc1bb97804af6631813c55739f771071e0f2ed33ee20b68c86ec505d906356c"
+checksum = "64e7a2beac087c1da2d21018a3b7f043fe2f138654ad9c1518d409061a4a0034"
+dependencies = [
+ "cc",
+ "secp256k1-sys 0.6.1",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a332be01508d814fed64bf28f798a146d73792121129962fdf335bb3c49a4254"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -3110,9 +3195,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.6.1"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
+checksum = "31c9bb296072e961fcbd8853511dd39c2d8be2deb1e17c6860b1d30732b323b4"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -3146,9 +3231,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.91"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
+checksum = "cad406b69c91885b5107daf2c29572f6c8cdb3c66826821e286c533490c0bc76"
 dependencies = [
  "itoa",
  "ryu",
@@ -3190,27 +3275,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sibyls"
 version = "0.1.0"
 dependencies = [
  "actix-web",
  "anyhow",
  "async-trait",
- "base64",
+ "base64 0.13.1",
  "chrono",
  "clap 3.2.23",
  "clokwerk",
  "config",
  "displaydoc",
- "dlc 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dlc 0.3.0",
  "dlc-clients",
- "dlc-messages 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dlc-messages 0.3.0",
  "env_logger",
  "futures",
  "gethostname",
  "hex",
  "humantime",
- "lightning",
+ "lightning 0.0.106",
  "log",
  "parking_lot 0.12.1",
  "queues",
@@ -3222,25 +3318,44 @@ dependencies = [
  "serde_json",
  "sled",
  "thiserror",
- "time 0.3.17",
+ "time 0.3.20",
  "tokio",
  "vaultrs",
 ]
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
 dependencies = [
  "libc",
 ]
 
 [[package]]
-name = "slab"
-version = "0.4.7"
+name = "similar"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
+checksum = "420acb44afdae038210c99e69aae24109f32f15500aa708e81d46c9f29d55fcf"
+
+[[package]]
+name = "simple-wallet"
+version = "0.1.0"
+source = "git+https://github.com/p2pderivatives/rust-dlc#ca4f9b04e652710d98cd4178fe1225285e3c8752"
+dependencies = [
+ "bitcoin 0.29.2",
+ "dlc 0.4.0",
+ "dlc-manager",
+ "lightning 0.0.113",
+ "rust-bitcoin-coin-selection",
+ "secp256k1-zkp 0.7.0",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
 dependencies = [
  "autocfg 1.1.0",
 ]
@@ -3308,9 +3423,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.107"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3364,45 +3479,34 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+checksum = "af18f7ae1acd354b992402e9ec5864359d693cd8a79dcbef59f76891701c1e95"
 dependencies = [
  "cfg-if",
  "fastrand",
- "libc",
  "redox_syscall",
- "remove_dir_all",
- "winapi",
+ "rustix",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
 name = "termcolor"
-version = "1.1.3"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
 ]
 
 [[package]]
 name = "terminal_size"
-version = "0.1.17"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "terminal_size"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb20089a8ba2b69debd491f8d2d023761cbf196e999218c591fa1e7e15a21907"
+checksum = "4c9afddd2cec1c0909f06b00ef33f94ab2cc0578c4a610aa208ddfec8aa2b43a"
 dependencies = [
  "rustix",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -3438,10 +3542,11 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.4"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
+ "cfg-if",
  "once_cell",
 ]
 
@@ -3467,9 +3572,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.17"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
+checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
 dependencies = [
  "itoa",
  "libc",
@@ -3487,9 +3592,9 @@ checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
 
 [[package]]
 name = "time-macros"
-version = "0.2.6"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d967f99f534ca7e495c575c62638eebc2898a8c84c119b89e250477bc4ba16b2"
+checksum = "fd80a657e71da814b8e5d60d3374fc6d35045062245d80224748ae522dd76f36"
 dependencies = [
  "time-core",
 ]
@@ -3517,15 +3622,15 @@ dependencies = [
 
 [[package]]
 name = "tinyvec_macros"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.23.0"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eab6d665857cc6ca78d6e80303a02cea7a7851e85dfbd77cbdc09bd129f1ef46"
+checksum = "c8e00990ebabbe4c14c08aca901caed183ecd5c09562a12c824bb53d3c3fd3af"
 dependencies = [
  "autocfg 1.1.0",
  "bytes",
@@ -3554,9 +3659,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-native-tls"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
  "tokio",
@@ -3575,9 +3680,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d660770404473ccd7bc9f8b28494a811bc18542b915c0855c51e8f419d5223ce"
+checksum = "8fb52b74f05dbf495a8fba459fdc331812b96aa086d9eb78101fa0d4569c3313"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -3598,9 +3703,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.4"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bb2e075f03b3d66d8d8785356224ba688d2906a371015e225beeb65ca92c740"
+checksum = "5427d89453009325de0d8f342c9490009f76e999cb7672d77e46267448f7e6b2"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3612,9 +3717,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.10"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1333c76748e868a4d9d1017b5ab53171dfd095f70c712fdb4653a406547f598f"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
  "serde",
 ]
@@ -3660,9 +3765,9 @@ dependencies = [
 
 [[package]]
 name = "try-lock"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
+checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "tungstenite"
@@ -3670,7 +3775,7 @@ version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e27992fd6a8c29ee7eef28fc78349aa244134e10ad447ce3b9f0ac0ed0fa4ce0"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "byteorder",
  "bytes",
  "http",
@@ -3726,9 +3831,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.8"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
+checksum = "d54675592c1dbefd78cbd98db9bacd89886e1ca50692a0692baefffdeb92dd58"
 
 [[package]]
 name = "unicode-ident"
@@ -3757,9 +3862,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
+checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
 name = "unicode-width"
@@ -3894,9 +3999,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
+checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -3904,9 +4009,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
+checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
 dependencies = [
  "bumpalo",
  "log",
@@ -3919,9 +4024,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23639446165ca5a5de86ae1d8896b737ae80319560fbaa4c2887b7da6e7ebd7d"
+checksum = "f219e0d211ba40266969f6dbdd90636da12f75bee4fc9d6c23d1260dadb51454"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -3931,9 +4036,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
+checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3941,9 +4046,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
+checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3954,15 +4059,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
+checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
 
 [[package]]
 name = "web-sys"
-version = "0.3.60"
+version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcda906d8be16e728fd5adc5b729afad4e444e106ab28cd1c7256e54fa61510f"
+checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4020,103 +4125,84 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
-dependencies = [
- "windows_aarch64_msvc 0.36.1",
- "windows_i686_gnu 0.36.1",
- "windows_i686_msvc 0.36.1",
- "windows_x86_64_gnu 0.36.1",
- "windows_x86_64_msvc 0.36.1",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
  "windows_aarch64_gnullvm",
- "windows_aarch64_msvc 0.42.0",
- "windows_i686_gnu 0.42.0",
- "windows_i686_msvc 0.42.0",
- "windows_x86_64_gnu 0.42.0",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
  "windows_x86_64_gnullvm",
- "windows_x86_64_msvc 0.42.0",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
+checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.36.1"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.36.1"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
+checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.36.1"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.36.1"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.36.1"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
+checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
 
 [[package]]
 name = "winreg"
@@ -4138,18 +4224,18 @@ dependencies = [
 
 [[package]]
 name = "zstd"
-version = "0.11.2+zstd.1.5.2"
+version = "0.12.3+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
+checksum = "76eea132fb024e0e13fd9c2f5d5d595d8a967aa72382ac2f9d39fcc95afd0806"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "5.0.2+zstd.1.5.2"
+version = "6.0.4+zstd.1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
+checksum = "7afb4b54b8910cf5447638cb54bf4e8a65cbedd783af98b98c62ffe91f185543"
 dependencies = [
  "libc",
  "zstd-sys",
@@ -4157,10 +4243,11 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.4+zstd.1.5.2"
+version = "2.0.7+zstd.1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fa202f2ef00074143e219d15b62ffc317d17cc33909feac471c044087cad7b0"
+checksum = "94509c3ba2fe55294d752b79842c530ccfab760192521df74a081a78d2b3c7f5"
 dependencies = [
  "cc",
  "libc",
+ "pkg-config",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -355,18 +355,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitcoin-rpc-provider"
+name = "bitcoin-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc#ca4f9b04e652710d98cd4178fe1225285e3c8752"
+source = "git+https://github.com/p2pderivatives/rust-dlc?tag=v0.4.0#51517f3f6ad764953983b001efc2eac197ddb080"
 dependencies = [
  "bitcoin 0.29.2",
  "bitcoincore-rpc",
  "bitcoincore-rpc-json",
- "dlc-manager",
- "lightning 0.0.113",
- "log",
- "rust-bitcoin-coin-selection",
- "simple-wallet",
 ]
 
 [[package]]
@@ -1066,7 +1061,7 @@ dependencies = [
 [[package]]
 name = "dlc"
 version = "0.4.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc#ca4f9b04e652710d98cd4178fe1225285e3c8752"
+source = "git+https://github.com/p2pderivatives/rust-dlc?tag=v0.4.0#51517f3f6ad764953983b001efc2eac197ddb080"
 dependencies = [
  "bitcoin 0.29.2",
  "miniscript",
@@ -1098,7 +1093,7 @@ dependencies = [
 [[package]]
 name = "dlc-manager"
 version = "0.4.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc#ca4f9b04e652710d98cd4178fe1225285e3c8752"
+source = "git+https://github.com/p2pderivatives/rust-dlc?tag=v0.4.0#51517f3f6ad764953983b001efc2eac197ddb080"
 dependencies = [
  "async-trait",
  "bitcoin 0.29.2",
@@ -1126,7 +1121,7 @@ dependencies = [
 [[package]]
 name = "dlc-messages"
 version = "0.4.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc#ca4f9b04e652710d98cd4178fe1225285e3c8752"
+source = "git+https://github.com/p2pderivatives/rust-dlc?tag=v0.4.0#51517f3f6ad764953983b001efc2eac197ddb080"
 dependencies = [
  "bitcoin 0.29.2",
  "dlc 0.4.0",
@@ -1140,9 +1135,7 @@ name = "dlc-protocol-wallet"
 version = "0.1.0"
 dependencies = [
  "base64 0.13.1",
- "bitcoin-rpc-provider",
- "bitcoincore-rpc",
- "bitcoincore-rpc-json",
+ "bitcoin 0.29.2",
  "chrono",
  "dlc 0.4.0",
  "dlc-clients",
@@ -1150,6 +1143,7 @@ dependencies = [
  "dlc-messages 0.4.0",
  "dlc-sled-storage-provider",
  "dlc-trie",
+ "electrs-blockchain-provider",
  "env_logger",
  "hex",
  "lightning 0.0.113",
@@ -1160,6 +1154,7 @@ dependencies = [
  "secp256k1-zkp 0.7.0",
  "serde",
  "serde_json",
+ "simple-wallet",
  "sled",
  "tokio",
  "warp",
@@ -1168,9 +1163,13 @@ dependencies = [
 [[package]]
 name = "dlc-sled-storage-provider"
 version = "0.1.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc#ca4f9b04e652710d98cd4178fe1225285e3c8752"
+source = "git+https://github.com/p2pderivatives/rust-dlc?tag=v0.4.0#51517f3f6ad764953983b001efc2eac197ddb080"
 dependencies = [
+ "bitcoin 0.29.2",
  "dlc-manager",
+ "lightning 0.0.113",
+ "secp256k1-zkp 0.7.0",
+ "simple-wallet",
  "sled",
 ]
 
@@ -1221,7 +1220,7 @@ dependencies = [
 [[package]]
 name = "dlc-trie"
 version = "0.4.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc#ca4f9b04e652710d98cd4178fe1225285e3c8752"
+source = "git+https://github.com/p2pderivatives/rust-dlc?tag=v0.4.0#51517f3f6ad764953983b001efc2eac197ddb080"
 dependencies = [
  "bitcoin 0.29.2",
  "dlc 0.4.0",
@@ -1258,6 +1257,23 @@ name = "either"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+
+[[package]]
+name = "electrs-blockchain-provider"
+version = "0.1.0"
+source = "git+https://github.com/p2pderivatives/rust-dlc?tag=v0.4.0#51517f3f6ad764953983b001efc2eac197ddb080"
+dependencies = [
+ "bitcoin 0.29.2",
+ "bitcoin-test-utils",
+ "dlc-manager",
+ "lightning 0.0.113",
+ "lightning-block-sync",
+ "reqwest",
+ "rust-bitcoin-coin-selection",
+ "serde",
+ "simple-wallet",
+ "tokio",
+]
 
 [[package]]
 name = "encode_unicode"
@@ -1974,6 +1990,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "087add70f81d2fdc6d4409bc0cef69e11ad366ef1d0068550159bd22b3ac8664"
 dependencies = [
  "bitcoin 0.29.2",
+]
+
+[[package]]
+name = "lightning-block-sync"
+version = "0.0.113"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2fc7227008536500026866e90d5e2db2da2725c5cdc7d19013df743d9de3e68"
+dependencies = [
+ "bitcoin 0.29.2",
+ "futures-util",
+ "lightning 0.0.113",
 ]
 
 [[package]]
@@ -3341,7 +3368,7 @@ checksum = "420acb44afdae038210c99e69aae24109f32f15500aa708e81d46c9f29d55fcf"
 [[package]]
 name = "simple-wallet"
 version = "0.1.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc#ca4f9b04e652710d98cd4178fe1225285e3c8752"
+source = "git+https://github.com/p2pderivatives/rust-dlc?tag=v0.4.0#51517f3f6ad764953983b001efc2eac197ddb080"
 dependencies = [
  "bitcoin 0.29.2",
  "dlc 0.4.0",

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -9,17 +9,17 @@ path = "src/main.rs"
 
 [dependencies]
 base64 = "0.13.1"
-bitcoin-rpc-provider = {version = "0.3.0", git = "https://github.com/dlc-link/rust-dlc", branch = "0.3.0-with-witness-fix"}
-bitcoincore-rpc = {version = "0.13.0", git = "https://github.com/p2pderivatives/rust-bitcoincore-rpc", branch = "dlc-version"}
-bitcoincore-rpc-json = {version = "0.13.0", git = "https://github.com/p2pderivatives/rust-bitcoincore-rpc", branch = "dlc-version"}
+bitcoin-rpc-provider = {version = "0.1.0", git = "https://github.com/p2pderivatives/rust-dlc"}
+bitcoincore-rpc = {version = "0.16.0"}
+bitcoincore-rpc-json = {version = "0.16.0"}
 chrono = {version = "0.4.19", features = ["serde"]}
-dlc = {version = "0.3.0", git = "https://github.com/dlc-link/rust-dlc", branch = "0.3.0-with-witness-fix", features = ["use-serde"]}
-dlc-manager = {version = "0.3.0", git = "https://github.com/dlc-link/rust-dlc", branch = "0.3.0-with-witness-fix", features = ["use-serde"]}
-dlc-messages = {version = "0.3.0", git = "https://github.com/dlc-link/rust-dlc", branch = "0.3.0-with-witness-fix", features = ["use-serde"]}
-dlc-trie = {version = "0.3.0", git = "https://github.com/dlc-link/rust-dlc", branch = "0.3.0-with-witness-fix", features = ["use-serde"]}
-dlc-sled-storage-provider = {version = "0.1.0", git = "https://github.com/dlc-link/rust-dlc", branch = "0.3.0-with-witness-fix"}
+dlc = {version = "0.4.0", git = "https://github.com/p2pderivatives/rust-dlc", features = ["use-serde"]}
+dlc-manager = {version = "0.4.0", git = "https://github.com/p2pderivatives/rust-dlc", features = ["use-serde"]}
+dlc-messages = {version = "0.4.0", git = "https://github.com/p2pderivatives/rust-dlc", features = ["use-serde"]}
+dlc-trie = {version = "0.4.0", git = "https://github.com/p2pderivatives/rust-dlc", features = ["use-serde"]}
+dlc-sled-storage-provider = {version = "0.1.0", git = "https://github.com/p2pderivatives/rust-dlc"}
 env_logger = "0.9.0"
-lightning = {version = "0.0.106"}
+lightning = {version = "0.0.113" }
 hex = "0.4"
 log = "0.4.17"
 reqwest = {version = "0.11", features = ["blocking", "json", "rustls-tls"]}
@@ -27,11 +27,10 @@ dlc-clients = { path = "../clients" }
 rouille = {version = "3.5.0"}
 serde = {version = "*", features = ["derive"]}
 serde_json = "1.0.81"
-secp256k1-zkp = {version = "0.5.0", features = ["bitcoin_hashes", "rand", "rand-std"]}
+secp256k1-zkp = {version = "0.7.0" }
 sled = "0.34"
 tokio = "1.23.0"
-# tokio = {version = "1", features = ["full"]}
 warp = "0.3"
 
 [dev-dependencies]
-mockito = "0.30.0"
+mockito = "0.31.0"

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -9,15 +9,14 @@ path = "src/main.rs"
 
 [dependencies]
 base64 = "0.13.1"
-bitcoin-rpc-provider = {version = "0.1.0", git = "https://github.com/p2pderivatives/rust-dlc"}
-bitcoincore-rpc = {version = "0.16.0"}
-bitcoincore-rpc-json = {version = "0.16.0"}
+bitcoin = {version = "0.29.2"}
 chrono = {version = "0.4.19", features = ["serde"]}
-dlc = {version = "0.4.0", git = "https://github.com/p2pderivatives/rust-dlc", features = ["use-serde"]}
-dlc-manager = {version = "0.4.0", git = "https://github.com/p2pderivatives/rust-dlc", features = ["use-serde"]}
-dlc-messages = {version = "0.4.0", git = "https://github.com/p2pderivatives/rust-dlc", features = ["use-serde"]}
-dlc-trie = {version = "0.4.0", git = "https://github.com/p2pderivatives/rust-dlc", features = ["use-serde"]}
-dlc-sled-storage-provider = {version = "0.1.0", git = "https://github.com/p2pderivatives/rust-dlc"}
+dlc = {version = "0.4.0", git = "https://github.com/p2pderivatives/rust-dlc", tag="v0.4.0", features = ["use-serde"]}
+dlc-manager = {version = "0.4.0", git = "https://github.com/p2pderivatives/rust-dlc", tag="v0.4.0", features = ["use-serde"]}
+dlc-messages = {version = "0.4.0", git = "https://github.com/p2pderivatives/rust-dlc", tag="v0.4.0", features = ["use-serde"]}
+dlc-trie = {version = "0.4.0", git = "https://github.com/p2pderivatives/rust-dlc", tag="v0.4.0", features = ["use-serde"]}
+dlc-sled-storage-provider = {version = "0.1.0", git = "https://github.com/p2pderivatives/rust-dlc", tag="v0.4.0", features=["wallet"]}
+electrs-blockchain-provider = {version = "0.1.0", git = "https://github.com/p2pderivatives/rust-dlc", tag="v0.4.0"}
 env_logger = "0.9.0"
 lightning = {version = "0.0.113" }
 hex = "0.4"
@@ -28,6 +27,7 @@ rouille = {version = "3.5.0"}
 serde = {version = "*", features = ["derive"]}
 serde_json = "1.0.81"
 secp256k1-zkp = {version = "0.7.0" }
+simple-wallet = {version = "0.1.0", git = "https://github.com/p2pderivatives/rust-dlc", tag="v0.4.0"}
 sled = "0.34"
 tokio = "1.23.0"
 warp = "0.3"

--- a/wallet/docker/.env.template
+++ b/wallet/docker/.env.template
@@ -1,7 +1,12 @@
 ORACLE_URL="https://dev-oracle.dlc.link/oracle"
-BTC_RPC_URL="btc.host/alice"
-RPC_USER="devnet2"
-RPC_PASS="devnet2"
+
+# For Internal DLC.Link Bitcoin Mocknet
+# ELECTRUM_API_URL="https://dev-oracle.dlc.link/electrs/"
+# For Bitcoin Testnet
+ELECTRUM_API_URL="https://blockstream.info/testnet/api/"
+# For Bitcoin Mainnet
+# ELECTRUM_API_URL="https://blockstream.info/api/"
+
 STORAGE_API_ENABLED=true
 STORAGE_API_ENDPOINT="https://dev-oracle.dlc.link/storage-api"
 USE_SLED=false

--- a/wallet/docker/.env.template
+++ b/wallet/docker/.env.template
@@ -7,6 +7,7 @@ ELECTRUM_API_URL="https://blockstream.info/testnet/api/"
 # For Bitcoin Mainnet
 # ELECTRUM_API_URL="https://blockstream.info/api/"
 
+BITCOIN_CHECK_INTERVAL_SECONDS=10 #min of 10
 STORAGE_API_ENABLED=true
 STORAGE_API_ENDPOINT="https://dev-oracle.dlc.link/storage-api"
 USE_SLED=false

--- a/wallet/src/main.rs
+++ b/wallet/src/main.rs
@@ -52,7 +52,10 @@ type DlcManager<'a> = Manager<
 >;
 
 const NUM_CONFIRMATIONS: u32 = 2;
-const COUNTER_PARTY_PK: &str = "02fc8e97419286cf05e5d133f41ff6d51f691dda039e9dc007245a421e2c7ec61c";
+
+// The contracts in dlc-manager expect a node id, but web extensions often don't have this, so hardcode it for now. Should not have any ramifications.
+const STATIC_COUNTERPARTY_NODE_ID: &str =
+    "02fc8e97419286cf05e5d133f41ff6d51f691dda039e9dc007245a421e2c7ec61c";
 
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -362,11 +365,10 @@ fn create_new_offer(
         contract_infos: vec![contract_info],
     };
 
-    match &manager
-        .lock()
-        .unwrap()
-        .send_offer(&contract_input, COUNTER_PARTY_PK.parse().unwrap())
-    {
+    match &manager.lock().unwrap().send_offer(
+        &contract_input,
+        STATIC_COUNTERPARTY_NODE_ID.parse().unwrap(),
+    ) {
         Ok(dlc) => {
             debug!(
                 "Create new offer dlc output: {}",
@@ -391,7 +393,7 @@ fn create_new_offer(
 fn accept_offer(accept_dlc: AcceptDlc, manager: Arc<Mutex<DlcManager>>) -> Response {
     if let Some(Message::Sign(sign)) = match manager.lock().unwrap().on_dlc_message(
         &Message::Accept(accept_dlc),
-        COUNTER_PARTY_PK.parse().unwrap(),
+        STATIC_COUNTERPARTY_NODE_ID.parse().unwrap(),
     ) {
         Ok(dlc) => dlc,
         Err(e) => {

--- a/wallet/src/main.rs
+++ b/wallet/src/main.rs
@@ -78,41 +78,13 @@ fn main() {
     let mut funded_uuids: Vec<String> = vec![];
 
     // Setup Blockchain Connection Object
-
-    // RPC CONFIG
-    // let auth = Auth::UserPass(
-    //     "testuser".to_string(),
-    //     "lq6zequb-gYTdF2_ZEUtr8ywTXzLYtknzWU4nV8uVoo=".to_string(),
-    // );
-    // let url = "http://localhost:18443/wallet/alice"; - localhost
-    // let url = "http://54.147.153.106:18443/"; - devnet
-    // let rpc_user: String = env::var("RPC_USER").unwrap_or("testuser".to_string());
-    // let rpc_pass: String =
-    //     env::var("RPC_PASS").unwrap_or("lq6zequb-gYTdF2_ZEUtr8ywTXzLYtknzWU4nV8uVoo=".to_string());
-    // let btc_rpc_url: String =
-    //     env::var("BTC_RPC_URL").unwrap_or("localhost:18443/wallet/alice".to_string());
-
-    // let auth = Auth::UserPass(rpc_user, rpc_pass);
-    // let rpc = Client::new(&format!("http://{}", btc_rpc_url), auth.clone()).unwrap();
-    // let bitcoin_core = Arc::new(BitcoinCoreProvider::new_from_rpc_client(rpc));
-
     // ELECTRUM / ELECTRS
-    // // mocknet
-    // let electrs_host = "https://dev-oracle.dlc.link/electrs/";
-    // testnet
-    let electrs_host = "https://blockstream.info/testnet/api/";
-    // // mainnet
-    // let electrs_host = "https://blockstream.info/api/";
+    let electrs_host =
+        env::var("ELECTRUM_API_URL").unwrap_or("https://blockstream.info/testnet/api/".to_string());
     let blockchain = Arc::new(ElectrsBlockchainProvider::new(
         electrs_host.to_string(),
         bitcoin::Network::Testnet,
     ));
-
-    // Blockcypher
-    // let blockchain = Arc::new(BlockcypherBlockchainProvider::new(
-    //     "https://api.blockcypher.com".to_string(),
-    //     bitcoin::Network::Testnet,
-    // ));
 
     // Set up DLC store
     let store = StorageProvider::new();

--- a/wallet/src/oracle_client.rs
+++ b/wallet/src/oracle_client.rs
@@ -72,30 +72,6 @@ struct AttestationResponse {
     values: Vec<String>,
 }
 
-// fn get<T>(path: &str) -> Result<T, DlcManagerError>
-// where
-//     T: serde::de::DeserializeOwned,
-// {
-//     reqwest::blocking::get(path)
-//         .map_err(|x| {
-//             dlc_manager::error::Error::IOError(std::io::Error::new(std::io::ErrorKind::Other, x))
-//         })?
-//         .json::<T>()
-//         .map_err(|e| dlc_manager::error::Error::OracleError(e.to_string()))
-// }
-
-// fn get_object<T>(path: &str) -> Result<T, DlcManagerError>
-// where
-//     T: serde::de::DeserializeOwned,
-// {
-//     reqwest::blocking::get(path)
-//         .map_err(|x| {
-//             dlc_manager::error::Error::IOError(std::io::Error::new(std::io::ErrorKind::Other, x))
-//         })?
-//         .json::<T>()
-//         .map_err(|e| dlc_manager::error::Error::OracleError(e.to_string()))
-// }
-
 fn get_object<T>(path: &str) -> Result<T, DlcManagerError>
 where
     T: serde::de::DeserializeOwned,
@@ -161,19 +137,6 @@ impl P2PDOracleClient {
         Ok(P2PDOracleClient { host, public_key })
     }
 }
-
-// fn parse_event_id(event_id: &str) -> Result<(String, DateTime<Utc>), DlcManagerError> {
-//     let asset_id = &event_id[..6];
-//     let timestamp_str = &event_id[6..];
-//     let timestamp: i64 = timestamp_str
-//         .parse()
-//         .map_err(|_| DlcManagerError::OracleError("Invalid timestamp format".to_string()))?;
-//     let naive_date_time = NaiveDateTime::from_timestamp_opt(timestamp, 0).ok_or_else(|| {
-//         DlcManagerError::InvalidParameters(format!("Invalid timestamp {} in event id", timestamp))
-//     })?;
-//     let date_time = DateTime::from_utc(naive_date_time, Utc);
-//     Ok((asset_id.to_string(), date_time))
-// }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DecodeHexError {

--- a/wallet/src/oracle_client.rs
+++ b/wallet/src/oracle_client.rs
@@ -1,5 +1,5 @@
-// ! # cg-oracle-client
-// ! Http client wrapper for the Crypto Garage DLC oracle
+//! # cg-oracle-client
+//! Http client wrapper for the Crypto Garage DLC oracle
 
 // Coding conventions
 #![deny(non_upper_case_globals)]
@@ -17,64 +17,52 @@ extern crate reqwest;
 extern crate secp256k1_zkp;
 extern crate serde;
 
-use core::str;
-use serde_json::Value;
-use std::fmt;
-use std::num::ParseIntError;
+use std::{fmt, io::Cursor, num::ParseIntError, str::FromStr};
 
-use std::io::Cursor;
-use std::str::FromStr;
-
-// use chrono::{DateTime, NaiveDateTime, Utc};
+use chrono::{DateTime, Utc};
 use dlc_manager::error::Error as DlcManagerError;
 use dlc_manager::Oracle;
 use dlc_messages::oracle_msgs::{OracleAnnouncement, OracleAttestation};
 use log::info;
-
-use secp256k1_zkp::schnorrsig::PublicKey;
-use secp256k1_zkp::schnorrsig::Signature;
+use secp256k1_zkp::{schnorr::Signature, XOnlyPublicKey};
+use serde_json::Value;
 
 /// Enables interacting with a DLC oracle.
 pub struct P2PDOracleClient {
     host: String,
-    public_key: PublicKey,
-    // key_pair: KeyPair,
-    // secp: Secp256k1<All>,
-    // announcements: Mutex<HashMap<String, OracleAnnouncement>>,
-    // attestations: Mutex<HashMap<String, OracleAttestation>>,
-    // nonces: Mutex<HashMap<String, Vec<SecretKey>>>,
+    public_key: XOnlyPublicKey,
 }
 
 #[derive(serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 struct PublicKeyResponse {
-    public_key: PublicKey,
+    public_key: XOnlyPublicKey,
 }
 
-// #[derive(serde::Deserialize, serde::Serialize)]
-// #[serde(rename_all = "camelCase")]
-// struct EventDescriptor {
-//     base: u16,
-//     is_signed: bool,
-//     unit: String,
-//     precision: i32,
-// }
+#[derive(serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct EventDescriptor {
+    base: u16,
+    is_signed: bool,
+    unit: String,
+    precision: i32,
+}
 
-// #[derive(serde::Deserialize, serde::Serialize)]
-// #[serde(rename_all = "camelCase")]
-// struct Event {
-//     nonces: Vec<PublicKey>,
-//     event_maturity: DateTime<Utc>,
-//     event_id: String,
-//     event_descriptor: EventDescriptor,
-// }
+#[derive(serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct Event {
+    nonces: Vec<XOnlyPublicKey>,
+    event_maturity: DateTime<Utc>,
+    event_id: String,
+    event_descriptor: EventDescriptor,
+}
 
-// #[derive(serde::Deserialize, serde::Serialize)]
-// #[serde(rename_all = "camelCase")]
-// struct AnnoucementResponse {
-//     oracle_public_key: PublicKey,
-//     oracle_event: Event,
-// }
+#[derive(serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct AnnoucementResponse {
+    oracle_public_key: XOnlyPublicKey,
+    oracle_event: Event,
+}
 
 #[derive(serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -85,6 +73,18 @@ struct AttestationResponse {
 }
 
 // fn get<T>(path: &str) -> Result<T, DlcManagerError>
+// where
+//     T: serde::de::DeserializeOwned,
+// {
+//     reqwest::blocking::get(path)
+//         .map_err(|x| {
+//             dlc_manager::error::Error::IOError(std::io::Error::new(std::io::ErrorKind::Other, x))
+//         })?
+//         .json::<T>()
+//         .map_err(|e| dlc_manager::error::Error::OracleError(e.to_string()))
+// }
+
+// fn get_object<T>(path: &str) -> Result<T, DlcManagerError>
 // where
 //     T: serde::de::DeserializeOwned,
 // {
@@ -119,16 +119,6 @@ fn get_json(path: &str) -> Result<Value, DlcManagerError> {
         })
 }
 
-/* deserialize the announcement object and should have it
-
-let mut announcement_cursor = Cursor::new(&event.1[6..]);
-    let decoded_announcement =
-        <dlc_messages::oracle_msgs::OracleAnnouncement as lightning::util::ser::Readable>::read(
-            &mut announcement_cursor,
-        )
-        .unwrap();
- */
-
 fn pubkey_path(host: &str) -> String {
     format!("{}{}", host, "v1/publickey")
 }
@@ -138,14 +128,8 @@ fn announcement_path(host: &str, event_id: &str) -> String {
 }
 
 fn attestation_path(host: &str, event_id: &str) -> String {
-    format!("{}v1/announcement/{}", host, event_id,)
+    format!("{}v1/announcement/{}", host, event_id)
 }
-
-// impl Default for P2PDOracleClient {
-//     fn default() -> Self {
-//         Self::new()
-//     }
-// }
 
 impl P2PDOracleClient {
     /// Try to create an instance of an oracle client connecting to the provided
@@ -171,12 +155,25 @@ impl P2PDOracleClient {
 
         info!("Oracle Pub Key: {}", public_key.to_string());
 
-        let public_key = PublicKey::from_str(&public_key)
+        let public_key = XOnlyPublicKey::from_str(&public_key)
             .map_err(|_| DlcManagerError::OracleError("Oracle PubKey Error".to_string()))?;
         info!("The p2pd oracle client has been created successfully");
         Ok(P2PDOracleClient { host, public_key })
     }
 }
+
+// fn parse_event_id(event_id: &str) -> Result<(String, DateTime<Utc>), DlcManagerError> {
+//     let asset_id = &event_id[..6];
+//     let timestamp_str = &event_id[6..];
+//     let timestamp: i64 = timestamp_str
+//         .parse()
+//         .map_err(|_| DlcManagerError::OracleError("Invalid timestamp format".to_string()))?;
+//     let naive_date_time = NaiveDateTime::from_timestamp_opt(timestamp, 0).ok_or_else(|| {
+//         DlcManagerError::InvalidParameters(format!("Invalid timestamp {} in event id", timestamp))
+//     })?;
+//     let date_time = DateTime::from_utc(naive_date_time, Utc);
+//     Ok((asset_id.to_string(), date_time))
+// }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DecodeHexError {
@@ -213,7 +210,7 @@ pub fn decode_hex(s: &str) -> Result<Vec<u8>, DecodeHexError> {
 }
 
 impl Oracle for P2PDOracleClient {
-    fn get_public_key(&self) -> PublicKey {
+    fn get_public_key(&self) -> XOnlyPublicKey {
         self.public_key
     }
 
@@ -223,7 +220,16 @@ impl Oracle for P2PDOracleClient {
         info!("Getting announcement at URL {path}");
         let v = get_json(&path)?;
 
-        let encoded_hex_announcement = v["rust_announcement"].as_str().unwrap(); //call to_string instead of as_str and watch your world crumble to pieces
+        let encoded_hex_announcement = match v["rust_announcement"].as_str() {
+            //call to_string instead of as_str and watch your world crumble to pieces
+            None => {
+                return Err(DlcManagerError::OracleError(format!(
+                    "missing announcement for event {}",
+                    event_id,
+                )))
+            }
+            Some(s) => s,
+        };
 
         let buffer = decode_hex(&encoded_hex_announcement).unwrap();
 
@@ -237,7 +243,10 @@ impl Oracle for P2PDOracleClient {
         Ok(decoded_announcement)
     }
 
-    fn get_attestation(&self, event_id: &str) -> Result<OracleAttestation, DlcManagerError> {
+    fn get_attestation(
+        &self,
+        event_id: &str,
+    ) -> Result<OracleAttestation, dlc_manager::error::Error> {
         let path = attestation_path(&self.host, event_id);
         let v = get_json(&path)?;
 
@@ -271,32 +280,19 @@ mod tests {
     extern crate mockito;
     use self::mockito::{mock, Mock};
     use super::*;
-    /*
-        #[test]
-        fn parse_event_test() {
-            let event_id = "btcusd1624943400";
-            let expected_asset_id = "btcusd";
-            let expected_date_time = DateTime::parse_from_rfc3339("2021-06-29T05:10:00Z").unwrap();
 
-            let (asset_id, date_time) = parse_event_id(event_id).expect("Error parsing event id");
-
-            assert_eq!(expected_asset_id, asset_id);
-            assert_eq!(expected_date_time, date_time);
-        }
-    */
     fn pubkey_mock() -> Mock {
         let path: &str = &pubkey_path("/");
-        mock("GET", path).with_body(
-            r#"{"publicKey":"ce4b7ad2b45de01f0897aa716f67b4c2f596e54506431e693f898712fe7e9bf3"}"#,
-        ).create()
+        mock("GET", path)
+            .with_body(r#""ce4b7ad2b45de01f0897aa716f67b4c2f596e54506431e693f898712fe7e9bf3""#)
+            .create()
     }
 
     #[test]
-    #[should_panic] // TODO: investigate that format issue (panic) is expected or not
     fn get_public_key_test() {
         let url = &mockito::server_url();
-        let _m = pubkey_mock();
-        let expected_pk: PublicKey =
+        let _pubkey_mock = pubkey_mock();
+        let expected_pk: XOnlyPublicKey =
             "ce4b7ad2b45de01f0897aa716f67b4c2f596e54506431e693f898712fe7e9bf3"
                 .parse()
                 .unwrap();
@@ -307,33 +303,31 @@ mod tests {
     }
 
     #[test]
-    #[should_panic] // TODO: investigate that format issue (panic) is expected or not
     fn get_announcement_test() {
         let url = &mockito::server_url();
         let _pubkey_mock = pubkey_mock();
-        let path: &str = &announcement_path("/", "2021-06-29T05:10:00Z");
-        let _m = mock("GET", path).with_body(r#"{"announcementSignature":"f83db0ca25e4c209b55156737b0c65470a9702fe9d1d19a129994786384289397895e403ff37710095a04a0841a95738e3e8bc35bdef6bce50bf34eeb182bd9b","oraclePublicKey":"10dc8cf51ae3ee1c7967ffb9c9633a5ab06206535d8e1319f005a01ba33bc05d","oracleEvent":{"oracleNonces":["aca32fc8dead13983c655638ef921f1d38ef2f5286e58b2a1dab32b6e086e208","89603f8179830590fdce45eb17ba8bdf74e295a4633b58b46c9ede8274774164","5f3fcdfbba9ec75cb0868e04ec1f97089b4153fb2076bd1e017048e9df633aa1","8436d00f7331491dc6512e560a1f2414be42e893992eccb495642eefc7c5bf37","0d2593764c9c27eba0be3ca6c71a2de4e49a5f4aa1ce1e2cc379be3939547501","414318491e96919e67583db7a47eb1f8b4f1194bcb5b5dcc4fd10492d89926e4","b9a5ded7295e0343f385e5abedfd9e5f4137de8f67de0afa9396f7e0f996ef79","badf0bfe230ed605161630d8e3a092d7448461042db38912bc6c6a0ab195ff71","6e4780213cd7ed9de1300146079b897cae89dec7800065f615974193f58aa6db","7b12b48ad95634ee4ca476dd57e634fddc328e10276e71d27e0ae626fad7d699","a8058604adf590a1c38f8be19aa44175eb2d1130eb4d7f39a34f89f0a3fbed27","ffc3208f60b585cdc778be1290b352c34c22652d5348a87885816bcf17a80116","cb34c13f80b49e729e863035f30e1f8ea7777618eedb6d666c3b1c85a5b8a637","5000991f4631c0bba5d026f02125fdbe77e019dde57d31ce7f23ae3601a18623","094433a2432b81bbb6d6b7d65dc3498e2a7c9de5f35672d67097d54d920eadd2","11dff6b40b0938e1943c7888633d88871c2a2a1c16f412b22b80ba7ed8af8788","d5957f1a199b4abbc06894479c722ad0c4f120f0d5afeb76d589127213e33170","80e09bb453e6a0a444ec3ba222a62ecd59540b9dd8280566a17bebdfdfbd7a9e","0fe775b79b2172cb961e7c1aa54d521360903680680aaa55ea8be0404ee3768c","bfcdbb2cbcffba41048149d4bcf2a41cd5fd0a713df6f48104ade3022c284575"],"eventMaturityEpoch":1653865200,"eventDescriptor":{"digitDecompositionEvent":{"base":2,"isSigned":false,"unit":"usd/btc","precision":0,"nbDigits":20}},"eventId":"btcusd1653865200"}}"#).create();
+        let path: &str = &announcement_path("/", "uniqueeventid123");
+        let _m = mock("GET", path).with_body(r#"{"event_id": "uniqueeventid123", "rust_announcement": "850d0f8cba638f2902dd75ba47dbc68662356249414ae90f5f3b0e8b85663801152045b10bad679c9a02ed627a33601f61ad90d97b76f1b78155192918e42d1a57c75f44e4dde2a17c0da725c160267e3307d771a33685dcd67ec79c7614722cfdd822fd021d000e2025053441f55e0096864bba15d3ab891f1a232a8518c06ea1ac745fc7fa13fc34f4f18e5fc392db419d0bd38f47b76a0f86ac60aaa67c426804a59c8ac214ce7a2f1c67e301d87f42575582e972f4a8b16f11236ad88630049fd96c9f711ce4c62b09d89ea422b696c366a14670908c229f9c5d4c43904ff5cd5ea096e6f35d08665144ef2dbacf4a6a9fadf3075a776d202ddd491ee85afd24bc4b47e2f23918a76ebb71f473575da7f2436ca5a62482676939bb74b7e3ebb0fdf70deadf9d51c403e606827b304dd65517786bcd08345d8db9885af942b4b71e60aa18175ace4035cc5c5480b3199c02691e9d411af63f6c15e9cabbecfea8f91c001e45019e29fe0e3c745a3c531a78f2f7e393a5f3a4f7179359c8cb6a8cce976a750ab98063b4eef7a4e131978c4d3d7bfccde62b7fd76f168d446095f24da149010d905e39eec4f3b455c91a72b5554710e452a0b589cb0e1a9c96b512e0aa4a21b3f4c8e2c124685067292527a74955d15f1df9909df53f7078a41c50778052f1f0aed958559fefde8dd391184ed71d069aa90663b419b9be889b8aecceedd5bde3c395553247438ccb277897493ca90c71f4b37925e565614374d7353e7c4f1d3bbb00000005fdd80a100002000642544355534400000000000e42307830306461633663393661616438666232666637376537613666313266626236646237346235333930623534343330613232393230633139373862336538336432"}"#).create();
 
         let client = P2PDOracleClient::new(url).expect("Error creating client instance");
 
         client
-            .get_announcement("btcusd1624943400")
+            .get_announcement("uniqueeventid123")
             .expect("Error getting announcement");
     }
 
     #[test]
-    #[should_panic] // TODO: investigate that format issue (panic) is expected or not
     fn get_attestation_test() {
         let url = &mockito::server_url();
         let _pubkey_mock = pubkey_mock();
-        let path: &str = &attestation_path("/", "2021-06-29T05:10:00Z");
+        let path: &str = &attestation_path("/", "uniqueeventid123");
 
-        let _m = mock("GET", path).with_body(r#"{"eventId":"btcusd1653517020","signatures":["ee05b1211d5f974732b10107dd302da062be47cd18f061c5080a50743412f9fd590cad90cfea762472e6fe865c4223bd388c877b7881a27892e15843ff1ac360","59ab83597089b48f5b3c2fd07c11edffa6b1180bdb6d9e7d6924979292d9c53fe79396ceb0782d5941c284d1642377136c06b2d9c2b85bda5969a773a971b5b0","d1f8c31a83bb34433da5b9808bb3692dd212b9022b7bc8f269fc817e96a7195db18262e934bebd4e68a3f2c96550826a5530350662df4c86c004f5cf1121ca67","e5cec554c39c4dd544d70175128271eecad77c1e3eaa6994c657e257d5c1c9dcd19b041ea8030e75448245b7f91705ad914c32761671a6172f928904b439ea6b","a209116d20f0931113c0880e8cd22d3f003609a32322ff8df241ef16e7d4efd1a9b723f582a22073e21188635f09f41f270f3126014542861be14b62b09c0ecc","f1da0b482f08f545a92338392b71cec33d948a5e5732ee4d5c0a87bd6b6cc12feeb1498da7afd93ae48ec4ce581ee79c0e92f338d3777c2ef06578e4ec1a853c","d9ab68244a3b47cc8cbd5a972f2f5059fc6b9711dba8d4a7a23607a99b9655593bab3abc1d3b02402cd0809c3c7016c741742efb363227de2bcfdcf290a053b3","c1146c1767a947f77794d05a2f58e50af824e3c8d70adde883e58d2dc1ddb157323b0aaf8cfb5b076a12395756bdcda64ab5d4799e43c88a41993659e6d49471","0d29d9383c9ee41055e1cb40104c9ca75280162779c0162cb6bf9aca2b223aba17de4b3f0f29ae6b749f22ba467b7e9f05456e8abb3ec328f62b7a924c6d4828","2bcc54002ceb271a940f24bc6dd0562b99c2d76cfb8f145f42ac37bc34fd3e94adba1194c5be91932b818c5715c73f287e066e228d796a373c4aec67fd777070","a91f77e3435c577682ff744d6f7da66c865a42e8645276dedf2ed2b8bc4c80285dff4b553b2231592e0fa8b4f242acb6888519fe82c457cc5204e5d9d511303a","546409d6bcdcfd5bef39957c8b1b09f7805b08ec2311bc73cf6927ae11f3567ffe8428aa7faa661518e9c02a702212ab05e494aab84624c3dd1a710f8c4c369b","9d601ee8a3d28dcdfdd05581f1b24d6e5a576f0b5544eb7c9921cb87a23fdb293c1edca89b43b5b84c1e305fbe52facbe6b03575aed8f95b4faccc90e0eb45ef","636b8028e9cd6cba6be5b3c1789b62aecfc17e9c28d7a621cfad2c3cf751046528028e1dbd6cee050d5d570cf5a3d8986471d73e7edca4093e36fc8e1097fb65","57c6337b52dc7fd8f49b29105f168fc9b4cb88ed2ba5f0e9a80a21e20836f87f875c3fe92afb437dd5647630b54eda6ba1be76ba6df8b641eb2e8be8ff1182dc","9e8843e32f9de4cd6d5bb9e938fd014babe11bb1faf35fc411d754259bc374f34dd841ed91f6bb3f030bc55a4791cdc41471c33b3f05fd35b9d1768fd381f953","97da4963747ab5e50534b93274065cba4fd24e6b7a9d3310db2596af24f70961fb03535e2a5ae272f7ea14e86daafa57073631596fecf7ceadf4ae3e6941b69e","94a414569743f87f1462a503be8cff1f229096d190b8b1349519c612b74eea872d5d763570aaaa54fad0605a43d742203bce489deea5570750030191e293c253","4d7117b89aad73eca7b341749bd54ffdd459b9b8b4ff128344d09273f66a3d2c01d2c86b61f7642d6e81f488580b456685cd68660458cff83b8858a05c9a1f4d","b12153a393a4fddac3079c1878cb89afccfe0ac8f539743c0608049f445e49ac7c89e33fcf832cda8d7e8a4f4dae94a303170f16c697feed8b78015873bd5ffc"],"values":["0","0","0","0","0","1","1","1","0","1","0","0","0","0","1","1","1","0","1","0"]}"#).create();
+        let _m = mock("GET", path).with_body(r#"{"event_id": "uniqueeventid123", "rust_attestation": "57c75f44e4dde2a17c0da725c160267e3307d771a33685dcd67ec79c7614722c000e435c1226b39a15c5c838bfede48e3991a7f635fc126b4d03818309967679f8ce6caf640dd446d196e2ce7d42309737ec6c9c7deeb2d2342f7d136d1adc47d8cbdbbf9310b26fa8d0e9bf1358c805398d0c0544982b86df7cea226ba3d90df5187e7ae34c2e9d4287388818702198a76a5e64a7542f47bb47e394122ca82a013d9b9f576b113886df98924027471624157cda05ac1e591d939233bea95ff858c1f07d0dde3e7b9eac58d3f0bee20c8a3883238656a68711571fc4f3394fd447c090d0aa53d0a79c066e98f3f7e8069b0e4fab53e65003ce09e75591815414b976d85b3b54620a006f26a756530b4380cdd3d7eb9624aa82ef81b613f06a97228194364a717f0ad64de704a1492afbe24fb58f9dcb60af9bbc4d493bec5dccf559b80cb34f313a7be4224d8ca40eaf38f0a2a2cb37bff478fe95467d8861dfd124945eb1a55c0b891b7adba33c2ce682b392b588634d7dd5a0304a16ded6de705af196897ce28b517b7f00d42c3e8220fc9b06d979131e93cce043e88281dc904fbebfa4d2e0612f9c3c612f974e582d282b944a026db59850a3b6d58e5d70a8eb555382b1300c4639471aa7c6d534a495e69ab98382225baa81e88ec7c849667529468f5534e1e25e984a53ad90a84063a10c21cf82d80fed7630db3b76a7c9a7ae633e64f3cbf9b78d5e43b5c2397d75c014c23c5c3362b87065044d5a4be86e0e6cd27c97dc188477821ec2ad5bf4fc8801570342003d05ba2aaa8dffb28882103121b6dd9d067dc8beba74cdec23bc2f97f0b9d650c745fc619e6d9b9196754894f78a9c0d7389e6dba483839b9a481673b84c965b1c3c1eb206a0fffc46e9b7298d08a0cd0453d1009e75a52eeffb2b46cf67f1b11cda16f83a1ec84ee57db6e9cd7011dcf24f378117ccf72f2fdae2db8f701fcfdf957b8ce3264493b9e20af28e009962bf5741139d2c95631e70105aecb53ad1a7fce3945a9a8e61e766eb98082e6be726c0a0d0c3f53faa550fc25188f1d65dd73df394de5929c223b4a952ed3f41dbb669d78b094283e5a62e20aac76aef9d352be841e5ded6e89a5dc662a54667ec91234aab02a06db5a68c689da223b152cfc4bceb03d1097322ec1c6672a5fd562b79892a1a4eaa1f4b2850ad4dc41427ced86f509e414ce915f54c51b3734bb11f28a7bd39afb2f04775b483a8a465faf4eee5449ff63cbbcfd7d22dd0c22d6a4dd49e3d8b96c37b5736bf0a4f9472d85552c13682a9d482bdf3000e01300130013001300130013001300130013001300130013001300130"}"#).create();
 
         let client = P2PDOracleClient::new(url).expect("Error creating client instance");
 
         client
-            .get_attestation("btcusd1624943400")
+            .get_attestation("uniqueeventid123")
             .expect("Error getting attestation");
     }
 }

--- a/wallet/src/storage/memory_storage.rs
+++ b/wallet/src/storage/memory_storage.rs
@@ -59,7 +59,10 @@ impl Storage for MemoryStorage {
             .collect())
     }
 
-    fn create_contract(&mut self, contract: &OfferedContract) -> Result<(), DaemonError> {
+    fn create_contract(
+        self: &MemoryStorage,
+        contract: &OfferedContract,
+    ) -> Result<(), DaemonError> {
         let mut map = self.contracts.write().expect("Could not get write lock");
         let uuid = get_contract_id_string(contract.id);
         info!("Create new contract with contract id {}", uuid.clone());
@@ -72,7 +75,7 @@ impl Storage for MemoryStorage {
         }
     }
 
-    fn delete_contract(&mut self, id: &ContractId) -> Result<(), DaemonError> {
+    fn delete_contract(self: &MemoryStorage, id: &ContractId) -> Result<(), DaemonError> {
         let mut map = self.contracts.write().expect("Could not get write lock");
         let uuid = get_contract_id_string(*id);
         info!("Delete contract with contract id {}", uuid.clone());
@@ -80,7 +83,7 @@ impl Storage for MemoryStorage {
         Ok(())
     }
 
-    fn update_contract(&mut self, contract: &Contract) -> Result<(), DaemonError> {
+    fn update_contract(self: &MemoryStorage, contract: &Contract) -> Result<(), DaemonError> {
         let mut map = self.contracts.write().expect("Could not get write lock");
         let contract_id: String = get_contract_id_string(contract.get_id());
         let curr_state = get_contract_state_str(contract);
@@ -153,5 +156,50 @@ impl Storage for MemoryStorage {
         }
 
         Ok(res)
+    }
+
+    fn upsert_channel(
+        &self,
+        _channel: dlc_manager::channel::Channel,
+        _contract: Option<Contract>,
+    ) -> Result<(), DaemonError> {
+        todo!()
+    }
+
+    fn delete_channel(&self, _channel_id: &dlc_manager::ChannelId) -> Result<(), DaemonError> {
+        todo!()
+    }
+
+    fn get_channel(
+        &self,
+        _channel_id: &dlc_manager::ChannelId,
+    ) -> Result<Option<dlc_manager::channel::Channel>, DaemonError> {
+        todo!()
+    }
+
+    fn get_signed_channels(
+        &self,
+        _channel_state: Option<dlc_manager::channel::signed_channel::SignedChannelStateType>,
+    ) -> Result<Vec<dlc_manager::channel::signed_channel::SignedChannel>, DaemonError> {
+        todo!()
+    }
+
+    fn get_offered_channels(
+        &self,
+    ) -> Result<Vec<dlc_manager::channel::offered_channel::OfferedChannel>, DaemonError> {
+        todo!()
+    }
+
+    fn persist_chain_monitor(
+        &self,
+        _monitor: &dlc_manager::chain_monitor::ChainMonitor,
+    ) -> Result<(), DaemonError> {
+        todo!()
+    }
+
+    fn get_chain_monitor(
+        &self,
+    ) -> Result<Option<dlc_manager::chain_monitor::ChainMonitor>, DaemonError> {
+        todo!()
     }
 }

--- a/wallet/src/storage/storage_api.rs
+++ b/wallet/src/storage/storage_api.rs
@@ -46,8 +46,8 @@ impl StorageApiProvider {
             contents.push(c.content);
         }
         for c in contents {
-            let bytes = base64::decode(c.clone()).unwrap();
-            let contract = deserialize_contract(&bytes).unwrap();
+            let bytes = base64::decode(c.clone()).map_err(to_storage_error)?;
+            let contract = deserialize_contract(&bytes)?;
             contracts.push(contract);
         }
         Ok(contracts)
@@ -87,7 +87,7 @@ impl Storage for StorageApiProvider {
         Ok(contracts)
     }
 
-    fn create_contract(&mut self, contract: &OfferedContract) -> Result<(), Error> {
+    fn create_contract(self: &StorageApiProvider, contract: &OfferedContract) -> Result<(), Error> {
         let data = serialize_contract(&Contract::Offered(contract.clone()))?;
         let uuid = get_contract_id_string(contract.id);
         info!("Create new contract with contract id {}", uuid.clone());
@@ -112,7 +112,7 @@ impl Storage for StorageApiProvider {
         }
     }
 
-    fn delete_contract(&mut self, id: &ContractId) -> Result<(), Error> {
+    fn delete_contract(self: &StorageApiProvider, id: &ContractId) -> Result<(), Error> {
         let cid = get_contract_id_string(*id);
         info!("Delete contract with contract id {}", cid.clone());
         let res = self
@@ -133,7 +133,7 @@ impl Storage for StorageApiProvider {
         }
     }
 
-    fn update_contract(&mut self, contract: &Contract) -> Result<(), Error> {
+    fn update_contract(self: &StorageApiProvider, contract: &Contract) -> Result<(), Error> {
         let contract_id: String = get_contract_id_string(contract.get_id());
         let curr_state = get_contract_state_str(contract);
         info!(
@@ -257,7 +257,7 @@ impl Storage for StorageApiProvider {
     }
 
     fn get_contract_offers(&self) -> Result<Vec<OfferedContract>, Error> {
-        let contracts_per_state = self.get_contracts_by_state("offered".to_string()).unwrap();
+        let contracts_per_state = self.get_contracts_by_state("offered".to_string())?;
         let mut res: Vec<OfferedContract> = Vec::new();
         for val in contracts_per_state {
             if let Contract::Offered(c) = val {
@@ -268,7 +268,7 @@ impl Storage for StorageApiProvider {
     }
 
     fn get_signed_contracts(&self) -> Result<Vec<SignedContract>, Error> {
-        let contracts_per_state = self.get_contracts_by_state("signed".to_string()).unwrap();
+        let contracts_per_state = self.get_contracts_by_state("signed".to_string())?;
         let mut res: Vec<SignedContract> = Vec::new();
         for val in contracts_per_state {
             if let Contract::Signed(c) = val {
@@ -279,9 +279,7 @@ impl Storage for StorageApiProvider {
     }
 
     fn get_confirmed_contracts(&self) -> Result<Vec<SignedContract>, Error> {
-        let contracts_per_state = self
-            .get_contracts_by_state("confirmed".to_string())
-            .unwrap();
+        let contracts_per_state = self.get_contracts_by_state("confirmed".to_string())?;
         let mut res: Vec<SignedContract> = Vec::new();
         for val in contracts_per_state {
             if let Contract::Confirmed(c) = val {
@@ -292,9 +290,7 @@ impl Storage for StorageApiProvider {
     }
 
     fn get_preclosed_contracts(&self) -> Result<Vec<PreClosedContract>, Error> {
-        let contracts_per_state = self
-            .get_contracts_by_state("pre_closed".to_string())
-            .unwrap();
+        let contracts_per_state = self.get_contracts_by_state("pre_closed".to_string())?;
         let mut res: Vec<PreClosedContract> = Vec::new();
         for val in contracts_per_state {
             if let Contract::PreClosed(c) = val {
@@ -302,5 +298,48 @@ impl Storage for StorageApiProvider {
             }
         }
         return Ok(res);
+    }
+
+    fn upsert_channel(
+        &self,
+        _channel: dlc_manager::channel::Channel,
+        _contract: Option<Contract>,
+    ) -> Result<(), Error> {
+        todo!()
+    }
+
+    fn delete_channel(&self, _channel_id: &dlc_manager::ChannelId) -> Result<(), Error> {
+        todo!()
+    }
+
+    fn get_channel(
+        &self,
+        _channel_id: &dlc_manager::ChannelId,
+    ) -> Result<Option<dlc_manager::channel::Channel>, Error> {
+        todo!()
+    }
+
+    fn get_signed_channels(
+        &self,
+        _channel_state: Option<dlc_manager::channel::signed_channel::SignedChannelStateType>,
+    ) -> Result<Vec<dlc_manager::channel::signed_channel::SignedChannel>, Error> {
+        todo!()
+    }
+
+    fn get_offered_channels(
+        &self,
+    ) -> Result<Vec<dlc_manager::channel::offered_channel::OfferedChannel>, Error> {
+        todo!()
+    }
+
+    fn persist_chain_monitor(
+        &self,
+        _monitor: &dlc_manager::chain_monitor::ChainMonitor,
+    ) -> Result<(), Error> {
+        todo!()
+    }
+
+    fn get_chain_monitor(&self) -> Result<Option<dlc_manager::chain_monitor::ChainMonitor>, Error> {
+        todo!()
     }
 }

--- a/wallet/src/storage/storage_provider.rs
+++ b/wallet/src/storage/storage_provider.rs
@@ -8,7 +8,7 @@ use dlc_manager::contract::{Contract, PreClosedContract};
 use dlc_manager::error::Error;
 use dlc_manager::{ContractId, Storage};
 use dlc_sled_storage_provider::SledStorageProvider;
-use log::info;
+use log::{debug, info};
 use std::env;
 
 pub struct StorageProvider {
@@ -92,12 +92,12 @@ impl Storage for StorageProvider {
         }
     }
 
-    fn create_contract(&mut self, contract: &OfferedContract) -> Result<(), Error> {
+    fn create_contract(self: &StorageProvider, contract: &OfferedContract) -> Result<(), Error> {
         if self.storage_api.is_some() {
-            self.storage_api.as_mut().unwrap().create_contract(contract)
+            self.storage_api.as_ref().unwrap().create_contract(contract)
         } else if self.sled_storage.is_some() {
             self.sled_storage
-                .as_mut()
+                .as_ref()
                 .unwrap()
                 .create_contract(contract)
         } else {
@@ -105,22 +105,22 @@ impl Storage for StorageProvider {
         }
     }
 
-    fn delete_contract(&mut self, id: &ContractId) -> Result<(), Error> {
+    fn delete_contract(self: &StorageProvider, id: &ContractId) -> Result<(), Error> {
         if self.storage_api.is_some() {
-            self.storage_api.as_mut().unwrap().delete_contract(id)
+            self.storage_api.as_ref().unwrap().delete_contract(id)
         } else if self.sled_storage.is_some() {
-            self.sled_storage.as_mut().unwrap().delete_contract(id)
+            self.sled_storage.as_ref().unwrap().delete_contract(id)
         } else {
             self.memory_storage.delete_contract(id)
         }
     }
 
-    fn update_contract(&mut self, contract: &Contract) -> Result<(), Error> {
+    fn update_contract(self: &StorageProvider, contract: &Contract) -> Result<(), Error> {
         if self.storage_api.is_some() {
-            self.storage_api.as_mut().unwrap().update_contract(contract)
+            self.storage_api.as_ref().unwrap().update_contract(contract)
         } else if self.sled_storage.is_some() {
             self.sled_storage
-                .as_mut()
+                .as_ref()
                 .unwrap()
                 .update_contract(contract)
         } else {
@@ -172,5 +172,49 @@ impl Storage for StorageProvider {
         } else {
             self.memory_storage.get_preclosed_contracts()
         }
+    }
+
+    fn upsert_channel(
+        &self,
+        _channel: dlc_manager::channel::Channel,
+        _contract: Option<Contract>,
+    ) -> Result<(), Error> {
+        todo!()
+    }
+
+    fn delete_channel(&self, _channel_id: &dlc_manager::ChannelId) -> Result<(), Error> {
+        todo!()
+    }
+
+    fn get_channel(
+        &self,
+        _channel_id: &dlc_manager::ChannelId,
+    ) -> Result<Option<dlc_manager::channel::Channel>, Error> {
+        todo!()
+    }
+
+    fn get_signed_channels(
+        &self,
+        _channel_state: Option<dlc_manager::channel::signed_channel::SignedChannelStateType>,
+    ) -> Result<Vec<dlc_manager::channel::signed_channel::SignedChannel>, Error> {
+        debug!("'get_signed_channels' Not Yet Implemented");
+        return Ok(vec![]);
+    }
+
+    fn get_offered_channels(
+        &self,
+    ) -> Result<Vec<dlc_manager::channel::offered_channel::OfferedChannel>, Error> {
+        todo!()
+    }
+
+    fn persist_chain_monitor(
+        &self,
+        _monitor: &dlc_manager::chain_monitor::ChainMonitor,
+    ) -> Result<(), Error> {
+        todo!()
+    }
+
+    fn get_chain_monitor(&self) -> Result<Option<dlc_manager::chain_monitor::ChainMonitor>, Error> {
+        todo!()
     }
 }

--- a/wallet/src/storage/storage_provider.rs
+++ b/wallet/src/storage/storage_provider.rs
@@ -8,7 +8,7 @@ use dlc_manager::contract::{Contract, PreClosedContract};
 use dlc_manager::error::Error;
 use dlc_manager::{ContractId, Storage};
 use dlc_sled_storage_provider::SledStorageProvider;
-use log::{debug, info};
+use log::{info, trace};
 use std::env;
 
 pub struct StorageProvider {
@@ -197,7 +197,7 @@ impl Storage for StorageProvider {
         &self,
         _channel_state: Option<dlc_manager::channel::signed_channel::SignedChannelStateType>,
     ) -> Result<Vec<dlc_manager::channel::signed_channel::SignedChannel>, Error> {
-        debug!("'get_signed_channels' Not Yet Implemented");
+        trace!("'get_signed_channels' Not Yet Implemented");
         return Ok(vec![]);
     }
 

--- a/wallet/src/storage/utils.rs
+++ b/wallet/src/storage/utils.rs
@@ -8,8 +8,6 @@ use dlc_manager::contract::ser::Serializable;
 use dlc_manager::contract::{ClosedContract, FailedAcceptContract, FailedSignContract};
 use std::fmt::Write as _;
 
-use log::{debug, info, warn};
-
 pub fn to_storage_error<T>(e: T) -> Error
 where
     T: std::fmt::Display,

--- a/wallet/src/storage/utils.rs
+++ b/wallet/src/storage/utils.rs
@@ -8,6 +8,8 @@ use dlc_manager::contract::ser::Serializable;
 use dlc_manager::contract::{ClosedContract, FailedAcceptContract, FailedSignContract};
 use std::fmt::Write as _;
 
+use log::{debug, info, warn};
+
 pub fn to_storage_error<T>(e: T) -> Error
 where
     T: std::fmt::Display,
@@ -66,20 +68,22 @@ convertible_enum!(
         Closed,
         FailedAccept,
         FailedSign,
-        Refunded,;
+        Refunded,
+        Rejected,;
     },
     Contract
 );
 
 pub fn serialize_contract(contract: &Contract) -> Result<Vec<u8>, ::std::io::Error> {
     let serialized = match contract {
-        Contract::Offered(o) => o.serialize(),
-        Contract::Accepted(o) => o.serialize(),
-        Contract::Signed(o) | Contract::Confirmed(o) | Contract::Refunded(o) => o.serialize(),
+        Contract::Offered(c) => c.serialize(),
+        Contract::Accepted(c) => c.serialize(),
+        Contract::Signed(c) | Contract::Confirmed(c) | Contract::Refunded(c) => c.serialize(),
         Contract::FailedAccept(c) => c.serialize(),
         Contract::FailedSign(c) => c.serialize(),
         Contract::PreClosed(c) => c.serialize(),
         Contract::Closed(c) => c.serialize(),
+        Contract::Rejected(c) => c.serialize(),
     };
     let mut serialized = serialized?;
     let mut res = Vec::with_capacity(serialized.len() + 1);
@@ -121,6 +125,9 @@ pub fn deserialize_contract(buff: &Vec<u8>) -> Result<Contract, Error> {
         ContractPrefix::Refunded => {
             Contract::Refunded(SignedContract::deserialize(&mut cursor).map_err(to_storage_error)?)
         }
+        ContractPrefix::Rejected => {
+            Contract::Rejected(OfferedContract::deserialize(&mut cursor).map_err(to_storage_error)?)
+        }
     };
     Ok(contract)
 }
@@ -136,6 +143,7 @@ pub fn get_contract_state_str(contract: &Contract) -> String {
         Contract::Refunded(_) => "refunded",
         Contract::FailedAccept(_) => "failed_accept",
         Contract::FailedSign(_) => "failed_sign",
+        Contract::Rejected(_) => "rejected",
     };
     return state.to_string();
 }


### PR DESCRIPTION
This PR implements various upgrades inside the rust_dlc package.

It also contains logic to allow this project to connect to bitcoin nodes via APIs. The internal wallet software used currently supports the electrum API format, see more here: https://github.com/Blockstream/esplora/blob/master/API.md

We have begun support of the Blockcypher API as well on another branch.