### PR TITLE
feat: attestorURLs for manager became optional

### DIFF
--- a/dlc-link-manager/src/lib.rs
+++ b/dlc-link-manager/src/lib.rs
@@ -19,10 +19,9 @@ use crate::dlc_manager::{Blockchain, Time, Wallet};
 use bitcoin::{Address, Transaction, Txid};
 
 use dlc_manager::ContractId;
-use dlc_messages::oracle_msgs::{self, OracleAnnouncement, OracleAttestation};
+use dlc_messages::oracle_msgs::{OracleAnnouncement, OracleAttestation};
 use dlc_messages::{AcceptDlc, Message as DlcMessage, OfferDlc, SignDlc};
 
-use futures::StreamExt;
 use log::*;
 use secp256k1_zkp::XOnlyPublicKey;
 use secp256k1_zkp::{All, PublicKey, Secp256k1};
@@ -477,14 +476,10 @@ where
                         .contract_info
                         .get(0)
                         .and_then(|info| info.oracle_announcements.get(0))
-                        .map(|announcement| announcement.oracle_event.event_id.clone());
+                        .map(|announcement| announcement.oracle_event.event_id.clone())
+                        .ok_or(Error::InvalidState("Missing oracle event ID".to_string()))?;
 
-                    match oracle_event_id {
-                        Some(event_id) => contracts_to_confirm.push((contract_id, event_id)),
-                        None => {
-                            return Err(Error::InvalidState("Missing oracle event ID".to_string()))
-                        }
-                    }
+                    contracts_to_confirm.push((contract_id, oracle_event_id));
                 }
                 Ok(false) => (),
                 Err(e) => error!(
@@ -521,14 +516,10 @@ where
                         .contract_info
                         .get(0)
                         .and_then(|info| info.oracle_announcements.get(0))
-                        .map(|announcement| announcement.oracle_event.event_id.clone());
+                        .map(|announcement| announcement.oracle_event.event_id.clone())
+                        .ok_or(Error::InvalidState("Missing oracle event ID".to_string()))?;
 
-                    match oracle_event_id {
-                        Some(event_id) => contracts_to_close.push((contract_id, event_id)),
-                        None => {
-                            return Err(Error::InvalidState("Missing oracle event ID".to_string()))
-                        }
-                    }
+                    contracts_to_close.push((contract_id, oracle_event_id));
                 }
                 Ok(false) => (),
             }
@@ -650,14 +641,10 @@ where
                         .contract_info
                         .get(0)
                         .and_then(|info| info.oracle_announcements.get(0))
-                        .map(|announcement| announcement.oracle_event.event_id.clone());
+                        .map(|announcement| announcement.oracle_event.event_id.clone())
+                        .ok_or(Error::InvalidState("Missing oracle event ID".to_string()))?;
 
-                    match oracle_event_id {
-                        Some(event_id) => contracts_to_close.push((contract_id, event_id)),
-                        None => {
-                            return Err(Error::InvalidState("Missing oracle event ID".to_string()))
-                        }
-                    }
+                    contracts_to_close.push((contract_id, oracle_event_id));
                 }
                 Ok(false) => (),
                 Err(e) => error!(

--- a/it/src/index.js
+++ b/it/src/index.js
@@ -169,8 +169,7 @@ async function main() {
     testWalletPrivateKey,
     testWalletAddress,
     bitcoinNetwork,
-    bitcoinNetworkURL,
-    JSON.stringify(attestorList)
+    bitcoinNetworkURL
   );
 
   //Checking Balance

--- a/wallet/src/main.rs
+++ b/wallet/src/main.rs
@@ -363,7 +363,7 @@ async fn main() -> Result<(), GenericError> {
         Arc::clone(&wallet),
         Arc::clone(&blockchain),
         dlc_store.clone(),
-        protocol_wallet_attestors.clone(),
+        Some(protocol_wallet_attestors),
         Arc::new(time_provider),
     )?);
 

--- a/wasm-wallet/src/lib.rs
+++ b/wasm-wallet/src/lib.rs
@@ -19,7 +19,7 @@ use secp256k1_zkp::Secp256k1;
 
 use core::panic;
 use std::fmt;
-use std::{collections::HashMap, io::Cursor, str::FromStr, sync::Arc};
+use std::{io::Cursor, str::FromStr, sync::Arc};
 
 use dlc_manager::{contract::Contract, ContractId, SystemTimeProvider};
 

--- a/wasm-wallet/src/lib.rs
+++ b/wasm-wallet/src/lib.rs
@@ -116,7 +116,6 @@ pub struct JsDLCInterface {
 // #[wasm_bindgen]
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct JsDLCInterfaceOptions {
-    attestor_urls: String,
     network: String,
     electrs_url: String,
     address: String,
@@ -126,7 +125,6 @@ impl Default for JsDLCInterfaceOptions {
     // Default values for Manager Options
     fn default() -> Self {
         Self {
-            attestor_urls: "https://devnet.dlc.link/oracle".to_string(),
             network: "regtest".to_string(),
             electrs_url: "https://devnet.dlc.link/electrs".to_string(),
             address: "".to_string(),
@@ -148,12 +146,10 @@ impl JsDLCInterface {
         address: String,
         network: String,
         electrs_url: String,
-        attestor_urls: String,
     ) -> Result<JsDLCInterface, JsError> {
         console_error_panic_hook::set_once();
 
         let options = JsDLCInterfaceOptions {
-            attestor_urls,
             network,
             electrs_url,
             address,
@@ -189,15 +185,6 @@ impl JsDLCInterface {
             PrivateKey::new(seckey, active_network),
         ));
 
-        // Set up Oracle Clients
-        let attestor_urls_vec: Vec<String> =
-            match serde_json::from_str(&options.attestor_urls.clone()) {
-                Ok(vec) => vec,
-                Err(e) => return Err(JsError::new(&format!("Error parsing attestor urls: {}", e))),
-            };
-
-        let attestors = generate_attestor_client(attestor_urls_vec).await?;
-
         // Set up time provider
         let time_provider = SystemTimeProvider {};
 
@@ -206,7 +193,7 @@ impl JsDLCInterface {
             Arc::clone(&wallet),
             Arc::clone(&blockchain),
             Box::new(dlc_store),
-            attestors,
+            None,
             Arc::new(time_provider),
         )?));
 


### PR DESCRIPTION
Attestors for manager are optional now, so wasm-wallet can instantiate a manager without attestorURLs.