### PR TITLE
feat: prevent double lock

### DIFF
--- a/clients/src/async_storage_provider.rs
+++ b/clients/src/async_storage_provider.rs
@@ -61,6 +61,28 @@ impl AsyncStorageApiProvider {
         }
         Ok(contracts)
     }
+
+    pub async fn get_contract_by_uuid(&self, uuid: String) -> Result<Option<DlcContract>, Error> {
+        let contract_res = self
+            .client
+            .get_contract(
+                ContractRequestParams {
+                    key: self.public_key.clone(),
+                    uuid,
+                },
+                self.secret_key,
+            )
+            .await
+            .map_err(to_storage_error)?;
+        match contract_res {
+            Some(res) => {
+                let bytes = base64::decode(res.content).map_err(to_storage_error)?;
+                let contract = deserialize_contract(&bytes).map_err(to_storage_error)?;
+                Ok(Some(contract))
+            }
+            _ => Ok(None),
+        }
+    }
 }
 
 impl AsyncStorage for AsyncStorageApiProvider {

--- a/it/src/index.js
+++ b/it/src/index.js
@@ -366,6 +366,11 @@ async function main() {
     `[IT] Contract state is not updated in the Router Wallet to Confirmed`
   );
 
+  //Fetching Offer
+  console.log('[IT] Checking if it is possible to fetch an offer with the same UUID again');
+  const offerResponseSecondTry = await fetchOfferFromProtocolWallet(testUUID, {  });
+
+  assert(offerResponseSecondTry.status === 400, '[IT] Offer should have failed, because the UUID is already used in a signed contract');
   // //Waiting for funding transaction confirmations
   // confirmedBroadcastTransaction = await waitForConfirmations(setupDetails2.blockchainHeightAtBroadcast, 6);
   // if (confirmedBroadcastTransaction) {

--- a/wallet/src/main.rs
+++ b/wallet/src/main.rs
@@ -279,11 +279,16 @@ async fn process_request(
                         ))
                     })?;
 
-                let contract = dlc_store.get_contract_by_uuid(req.uuid.clone()).await;
+                let signed_contract = dlc_store
+                    .check_if_signed_contract_exists_by_uuid(req.uuid.clone())
+                    .await
+                    .map_err(|e| {
+                        WalletError(format!("Error checking if contract exists: {}", e))
+                    })?;
 
-                if let Ok(Some(Contract::Signed(_))) = contract {
+                if signed_contract.is_some() {
                     return Err(WalletError(format!(
-                        "Contract with uuid {} is already signed",
+                        "Couldn't create offer, signed contract with uuid {} already exists",
                         req.uuid.clone()
                     )));
                 }

--- a/wallet/src/main.rs
+++ b/wallet/src/main.rs
@@ -279,6 +279,15 @@ async fn process_request(
                         ))
                     })?;
 
+                let contract = dlc_store.get_contract_by_uuid(req.uuid.clone()).await;
+
+                if let Ok(Some(Contract::Signed(_))) = contract {
+                    return Err(WalletError(format!(
+                        "Contract with uuid {} is already signed",
+                        req.uuid.clone()
+                    )));
+                }
+
                 create_new_offer(
                     manager,
                     attestors,


### PR DESCRIPTION
ThisPR adds a verification step to check for the existence of a signed contract associated with the provided UUID in the offer request. If a matching contract is found, an error is thrown, and the offer creation process is halted.