### PR TITLE
feat: adds prometheus metrics registry and counter to the router wallet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -910,6 +910,7 @@ dependencies = [
  "lightning",
  "log",
  "pretty_env_logger",
+ "prometheus-client",
  "reqwest",
  "rustls",
  "secp256k1-zkp",
@@ -1027,6 +1028,12 @@ name = "dotenv"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
+
+[[package]]
+name = "dtoa"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcbb2bf8e87535c23f7a8a321e364ce21462d0ff10cb6407820e8e96dfff6653"
 
 [[package]]
 name = "either"
@@ -2008,6 +2015,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prometheus-client"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "510c4f1c9d81d556458f94c98f857748130ea9737bbd6053da497503b26ea63c"
+dependencies = [
+ "dtoa",
+ "itoa",
+ "parking_lot 0.12.1",
+ "prometheus-client-derive-encode",
+]
+
+[[package]]
+name = "prometheus-client-derive-encode"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.31",
 ]
 
 [[package]]

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -29,6 +29,7 @@ http = "0.2"
 http-body = "=1.0.0-rc.2"
 log = "0.4.17"
 reqwest = {version = "0.11", features = ["blocking", "json", "rustls-tls"]}
+prometheus-client = "0.22.0"
 serde = {version = "1.0.193", features = ["derive"]}
 serde_json = "1.0.81"
 secp256k1-zkp = {version = "0.7.0" }


### PR DESCRIPTION
This PR introduces a Prometheus registry and implements metrics to track the number of requests, successes, and errors for the wallet's offer-related endpoints.